### PR TITLE
Add movie details screen and navigation

### DIFF
--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -1,5 +1,7 @@
 import 'package:auto_route/auto_route.dart';
-import  '../../features/screens.dart';
+
+import '../../features/movies/domain/models/movie.dart';
+import '../../features/screens.dart';
 
 part 'router.gr.dart';
 
@@ -10,5 +12,6 @@ class AppRouter extends _$AppRouter {
   List<AutoRoute> get routes => [
     AutoRoute(page: MainHomeRoute.page, initial: true),
     AutoRoute(page: MoviesRoute.page),
+    AutoRoute(page: MovieDetailsRoute.page),
   ];
 }

--- a/lib/core/router/router.gr.dart
+++ b/lib/core/router/router.gr.dart
@@ -39,6 +39,15 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const MoviesScreen(),
       );
     },
+    MovieDetailsRoute.name: (routeData) {
+      final args = routeData.argsAs<MovieDetailsRouteArgs>();
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: MovieDetailsScreen(
+          movie: args.movie,
+        ),
+      );
+    },
     ProfileRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
@@ -114,6 +123,35 @@ class MoviesRoute extends PageRouteInfo<void> {
   static const String name = 'MoviesRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [MovieDetailsScreen]
+class MovieDetailsRoute extends PageRouteInfo<MovieDetailsRouteArgs> {
+  MovieDetailsRoute({required Movie movie, List<PageRouteInfo>? children})
+      : super(
+          MovieDetailsRoute.name,
+          args: MovieDetailsRouteArgs(
+            movie: movie,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'MovieDetailsRoute';
+
+  static const PageInfo<MovieDetailsRouteArgs> page =
+      PageInfo<MovieDetailsRouteArgs>(name);
+}
+
+class MovieDetailsRouteArgs {
+  const MovieDetailsRouteArgs({required this.movie});
+
+  final Movie movie;
+
+  @override
+  String toString() {
+    return 'MovieDetailsRouteArgs{movie: $movie}';
+  }
 }
 
 /// generated route for

--- a/lib/features/movies/presentation/screens/movie_details_screen.dart
+++ b/lib/features/movies/presentation/screens/movie_details_screen.dart
@@ -1,0 +1,222 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+
+import '../../domain/models/movie.dart';
+
+@RoutePage()
+class MovieDetailsScreen extends StatelessWidget {
+  const MovieDetailsScreen({super.key, required this.movie});
+
+  final Movie movie;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final backdropUrl = movie.backdropPath != null
+        ? 'https://image.tmdb.org/t/p/w780/${movie.backdropPath}'
+        : null;
+    final posterUrl = movie.posterPath != null
+        ? 'https://image.tmdb.org/t/p/w342/${movie.posterPath}'
+        : null;
+    final voteAverage = movie.voteAverage != null
+        ? movie.voteAverage!.toStringAsFixed(1)
+        : '–';
+    final voteCount = movie.voteCount?.toString() ?? '–';
+    final releaseDate = movie.releaseDate ?? 'Unknown';
+    final language = movie.originalLanguage?.toUpperCase() ?? 'N/A';
+    final popularity = movie.popularity != null
+        ? movie.popularity!.toStringAsFixed(0)
+        : '–';
+
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          SliverAppBar(
+            backgroundColor: theme.colorScheme.surface,
+            expandedHeight: 320,
+            pinned: true,
+            flexibleSpace: FlexibleSpaceBar(
+              title: Text(movie.title ?? 'Movie Details'),
+              background: Stack(
+                fit: StackFit.expand,
+                children: [
+                  if (backdropUrl != null)
+                    Image.network(
+                      backdropUrl,
+                      fit: BoxFit.cover,
+                    )
+                  else
+                    Container(color: Colors.black12),
+                  const DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Colors.transparent,
+                          Colors.black54,
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (posterUrl != null)
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(12),
+                          child: Image.network(
+                            posterUrl,
+                            width: 120,
+                            height: 180,
+                            fit: BoxFit.cover,
+                          ),
+                        )
+                      else
+                        Container(
+                          width: 120,
+                          height: 180,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(12),
+                            color: theme.colorScheme.surfaceVariant,
+                          ),
+                          child: const Icon(Icons.movie, size: 48),
+                        ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              movie.title ?? 'Untitled',
+                              style: textTheme.headlineSmall?.copyWith(
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Wrap(
+                              spacing: 8,
+                              runSpacing: 8,
+                              children: [
+                                _InfoChip(icon: Icons.calendar_today, label: releaseDate),
+                                _InfoChip(icon: Icons.language, label: language),
+                                _InfoChip(icon: Icons.people, label: 'Votes $voteCount'),
+                                _InfoChip(icon: Icons.trending_up, label: 'Popularity $popularity'),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  Row(
+                    children: [
+                      Icon(Icons.star, color: theme.colorScheme.secondary),
+                      const SizedBox(width: 8),
+                      Text(
+                        voteAverage,
+                        style: textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text('User Score', style: textTheme.titleMedium),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Overview',
+                    style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    movie.overview?.isNotEmpty == true
+                        ? movie.overview!
+                        : 'No overview available for this movie yet.',
+                    style: textTheme.bodyLarge,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Additional Details',
+                    style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  _InfoRow(title: 'Original Title', value: movie.originalTitle ?? '–'),
+                  _InfoRow(title: 'Release Date', value: releaseDate),
+                  _InfoRow(title: 'Original Language', value: language),
+                  _InfoRow(title: 'Adult', value: movie.adult == true ? 'Yes' : 'No'),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Chip(
+      avatar: Icon(icon, size: 18, color: theme.colorScheme.onSecondaryContainer),
+      label: Text(label),
+      backgroundColor: theme.colorScheme.secondaryContainer,
+      labelStyle: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSecondaryContainer,
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.title, required this.value});
+
+  final String title;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 140,
+            child: Text(
+              title,
+              style: textTheme.titleMedium,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              value,
+              style: textTheme.bodyLarge,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/movies/presentation/widgets/movie_card.dart
+++ b/lib/features/movies/presentation/widgets/movie_card.dart
@@ -1,6 +1,8 @@
 import 'dart:math';
 
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:tmdb_flutter_app/core/router/router.gr.dart';
 
 import '../../domain/models/movie.dart';
 
@@ -28,8 +30,9 @@ class MovieCard extends StatelessWidget {
 
     return GestureDetector(
       onTap: () {
-        // Navigate to details screen with the selected movie
-        // context.router.push(MovieDetailsRoute(movie: movie));
+        if (movie != null) {
+          context.router.push(MovieDetailsRoute(movie: movie!));
+        }
       },
       child: Padding(
         padding: const EdgeInsets.only(bottom: 8.0),

--- a/lib/features/screens.dart
+++ b/lib/features/screens.dart
@@ -2,6 +2,7 @@
 export '../features/main_home_screen.dart';
 export '../features/home/presentation/screens/home_screen.dart';
 export '../features/movies/presentation/screens/movies_screen.dart';
+export '../features/movies/presentation/screens/movie_details_screen.dart';
 export '../features/profile/presentation/screens/profile_screen.dart';
 export '../features/tv_shows/presentation/screens/tv_shows_screen.dart';
 export '../features/search/presentation/screens/search_screen.dart';


### PR DESCRIPTION
## Summary
- add a dedicated movie details screen that highlights artwork, ratings, overview, and metadata
- update the router configuration to expose the new MovieDetails route
- hook up movie cards so tapping them opens the movie details screen

## Testing
- Not run (flutter tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dece9e98d48323bb5daa5bea648b84