### PR TITLE
Add actor details domain model and use case

### DIFF
--- a/lib/features/actors/data/repositories/actors_repository_impl.dart
+++ b/lib/features/actors/data/repositories/actors_repository_impl.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:tmdb_flutter_app/features/actors/domain/models/actor_details.dart';
 import 'package:tmdb_flutter_app/features/actors/domain/models/actors_list_result.dart';
 import 'package:tmdb_flutter_app/features/actors/domain/repositories/actors_repository.dart';
 
@@ -56,6 +57,35 @@ class ActorsRepositoryImpl extends ActorsRepository {
 
 
     // return _fetchActorsFromApi(endpoint, params);
+  }
+
+  @override
+  Future<ActorDetails> getActorDetails(
+    int actorId,
+    String apiKey,
+    String language,
+  ) async {
+    final params = {
+      'api_key': apiKey,
+      'language': language,
+      'append_to_response': 'combined_credits',
+    };
+
+    try {
+      final response = await dio.get(
+        '/person/$actorId',
+        queryParameters: params,
+      );
+
+      final data = response.data as Map<String, dynamic>;
+      return ActorDetails.fromJson(data);
+    } on DioException catch (e) {
+      final status = e.response?.statusCode;
+      final msg = _readableDioMessage(e);
+      throw FetchActorsException(message: msg, statusCode: status);
+    } catch (e) {
+      throw FetchActorsException(message: e.toString());
+    }
   }
 
   String _readableDioMessage(DioException e) {

--- a/lib/features/actors/domain/models/actor_details.dart
+++ b/lib/features/actors/domain/models/actor_details.dart
@@ -1,0 +1,290 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'actor_details.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class ActorDetails extends Equatable {
+  const ActorDetails({
+    this.adult,
+    this.alsoKnownAs,
+    this.biography,
+    this.birthday,
+    this.combinedCredits,
+    this.deathday,
+    this.gender,
+    this.homepage,
+    required this.id,
+    this.imdbId,
+    this.knownForDepartment,
+    this.name,
+    this.placeOfBirth,
+    this.popularity,
+    this.profilePath,
+  });
+
+  final bool? adult;
+  @JsonKey(name: 'also_known_as')
+  final List<String>? alsoKnownAs;
+  final String? biography;
+  final String? birthday;
+  @JsonKey(name: 'combined_credits')
+  final CombinedCredits? combinedCredits;
+  final String? deathday;
+  final int? gender;
+  final String? homepage;
+  final int id;
+  @JsonKey(name: 'imdb_id')
+  final String? imdbId;
+  @JsonKey(name: 'known_for_department')
+  final String? knownForDepartment;
+  final String? name;
+  @JsonKey(name: 'place_of_birth')
+  final String? placeOfBirth;
+  final double? popularity;
+  @JsonKey(name: 'profile_path')
+  final String? profilePath;
+
+  @override
+  List<Object?> get props => [
+        adult,
+        alsoKnownAs,
+        biography,
+        birthday,
+        combinedCredits,
+        deathday,
+        gender,
+        homepage,
+        id,
+        imdbId,
+        knownForDepartment,
+        name,
+        placeOfBirth,
+        popularity,
+        profilePath,
+      ];
+
+  factory ActorDetails.fromJson(Map<String, dynamic> json) =>
+      _$ActorDetailsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ActorDetailsToJson(this);
+}
+
+@JsonSerializable()
+class CombinedCredits extends Equatable {
+  const CombinedCredits({
+    this.cast = const [],
+    this.crew = const [],
+  });
+
+  @JsonKey(defaultValue: [])
+  final List<ActorCastCredit> cast;
+  @JsonKey(defaultValue: [])
+  final List<ActorCrewCredit> crew;
+
+  @override
+  List<Object?> get props => [cast, crew];
+
+  factory CombinedCredits.fromJson(Map<String, dynamic> json) =>
+      _$CombinedCreditsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CombinedCreditsToJson(this);
+}
+
+@JsonSerializable()
+class ActorCastCredit extends Equatable {
+  const ActorCastCredit({
+    this.adult,
+    this.backdropPath,
+    this.character,
+    this.creditId,
+    this.episodeCount,
+    this.firstAirDate,
+    this.genreIds,
+    this.id,
+    this.mediaType,
+    this.name,
+    this.originCountry,
+    this.originalLanguage,
+    this.originalName,
+    this.originalTitle,
+    this.overview,
+    this.popularity,
+    this.posterPath,
+    this.releaseDate,
+    this.title,
+    this.video,
+    this.voteAverage,
+    this.voteCount,
+    this.order,
+  });
+
+  final bool? adult;
+  @JsonKey(name: 'backdrop_path')
+  final String? backdropPath;
+  final String? character;
+  @JsonKey(name: 'credit_id')
+  final String? creditId;
+  @JsonKey(name: 'episode_count')
+  final int? episodeCount;
+  @JsonKey(name: 'first_air_date')
+  final String? firstAirDate;
+  @JsonKey(name: 'genre_ids')
+  final List<int>? genreIds;
+  final int? id;
+  @JsonKey(name: 'media_type')
+  final String? mediaType;
+  final String? name;
+  @JsonKey(name: 'origin_country')
+  final List<String>? originCountry;
+  @JsonKey(name: 'original_language')
+  final String? originalLanguage;
+  @JsonKey(name: 'original_name')
+  final String? originalName;
+  @JsonKey(name: 'original_title')
+  final String? originalTitle;
+  final String? overview;
+  final double? popularity;
+  @JsonKey(name: 'poster_path')
+  final String? posterPath;
+  @JsonKey(name: 'release_date')
+  final String? releaseDate;
+  final String? title;
+  final bool? video;
+  @JsonKey(name: 'vote_average')
+  final double? voteAverage;
+  @JsonKey(name: 'vote_count')
+  final int? voteCount;
+  final int? order;
+
+  @override
+  List<Object?> get props => [
+        adult,
+        backdropPath,
+        character,
+        creditId,
+        episodeCount,
+        firstAirDate,
+        genreIds,
+        id,
+        mediaType,
+        name,
+        originCountry,
+        originalLanguage,
+        originalName,
+        originalTitle,
+        overview,
+        popularity,
+        posterPath,
+        releaseDate,
+        title,
+        video,
+        voteAverage,
+        voteCount,
+        order,
+      ];
+
+  factory ActorCastCredit.fromJson(Map<String, dynamic> json) =>
+      _$ActorCastCreditFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ActorCastCreditToJson(this);
+}
+
+@JsonSerializable()
+class ActorCrewCredit extends Equatable {
+  const ActorCrewCredit({
+    this.adult,
+    this.backdropPath,
+    this.creditId,
+    this.department,
+    this.episodeCount,
+    this.firstAirDate,
+    this.genreIds,
+    this.id,
+    this.job,
+    this.mediaType,
+    this.name,
+    this.originCountry,
+    this.originalLanguage,
+    this.originalName,
+    this.originalTitle,
+    this.overview,
+    this.popularity,
+    this.posterPath,
+    this.releaseDate,
+    this.title,
+    this.video,
+    this.voteAverage,
+    this.voteCount,
+  });
+
+  final bool? adult;
+  @JsonKey(name: 'backdrop_path')
+  final String? backdropPath;
+  @JsonKey(name: 'credit_id')
+  final String? creditId;
+  final String? department;
+  @JsonKey(name: 'episode_count')
+  final int? episodeCount;
+  @JsonKey(name: 'first_air_date')
+  final String? firstAirDate;
+  @JsonKey(name: 'genre_ids')
+  final List<int>? genreIds;
+  final int? id;
+  final String? job;
+  @JsonKey(name: 'media_type')
+  final String? mediaType;
+  final String? name;
+  @JsonKey(name: 'origin_country')
+  final List<String>? originCountry;
+  @JsonKey(name: 'original_language')
+  final String? originalLanguage;
+  @JsonKey(name: 'original_name')
+  final String? originalName;
+  @JsonKey(name: 'original_title')
+  final String? originalTitle;
+  final String? overview;
+  final double? popularity;
+  @JsonKey(name: 'poster_path')
+  final String? posterPath;
+  @JsonKey(name: 'release_date')
+  final String? releaseDate;
+  final String? title;
+  final bool? video;
+  @JsonKey(name: 'vote_average')
+  final double? voteAverage;
+  @JsonKey(name: 'vote_count')
+  final int? voteCount;
+
+  @override
+  List<Object?> get props => [
+        adult,
+        backdropPath,
+        creditId,
+        department,
+        episodeCount,
+        firstAirDate,
+        genreIds,
+        id,
+        job,
+        mediaType,
+        name,
+        originCountry,
+        originalLanguage,
+        originalName,
+        originalTitle,
+        overview,
+        popularity,
+        posterPath,
+        releaseDate,
+        title,
+        video,
+        voteAverage,
+        voteCount,
+      ];
+
+  factory ActorCrewCredit.fromJson(Map<String, dynamic> json) =>
+      _$ActorCrewCreditFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ActorCrewCreditToJson(this);
+}

--- a/lib/features/actors/domain/models/actor_details.g.dart
+++ b/lib/features/actors/domain/models/actor_details.g.dart
@@ -1,0 +1,184 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'actor_details.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ActorDetails _$ActorDetailsFromJson(Map<String, dynamic> json) => ActorDetails(
+      adult: json['adult'] as bool?,
+      alsoKnownAs: (json['also_known_as'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      biography: json['biography'] as String?,
+      birthday: json['birthday'] as String?,
+      combinedCredits: json['combined_credits'] == null
+          ? null
+          : CombinedCredits.fromJson(
+              json['combined_credits'] as Map<String, dynamic>,
+            ),
+      deathday: json['deathday'] as String?,
+      gender: (json['gender'] as num?)?.toInt(),
+      homepage: json['homepage'] as String?,
+      id: (json['id'] as num).toInt(),
+      imdbId: json['imdb_id'] as String?,
+      knownForDepartment: json['known_for_department'] as String?,
+      name: json['name'] as String?,
+      placeOfBirth: json['place_of_birth'] as String?,
+      popularity: (json['popularity'] as num?)?.toDouble(),
+      profilePath: json['profile_path'] as String?,
+    );
+
+Map<String, dynamic> _$ActorDetailsToJson(ActorDetails instance) =>
+    <String, dynamic>{
+      'adult': instance.adult,
+      'also_known_as': instance.alsoKnownAs,
+      'biography': instance.biography,
+      'birthday': instance.birthday,
+      'combined_credits': instance.combinedCredits?.toJson(),
+      'deathday': instance.deathday,
+      'gender': instance.gender,
+      'homepage': instance.homepage,
+      'id': instance.id,
+      'imdb_id': instance.imdbId,
+      'known_for_department': instance.knownForDepartment,
+      'name': instance.name,
+      'place_of_birth': instance.placeOfBirth,
+      'popularity': instance.popularity,
+      'profile_path': instance.profilePath,
+    };
+
+CombinedCredits _$CombinedCreditsFromJson(Map<String, dynamic> json) =>
+    CombinedCredits(
+      cast: (json['cast'] as List<dynamic>?)
+              ?.map((e) => ActorCastCredit.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      crew: (json['crew'] as List<dynamic>?)
+              ?.map((e) => ActorCrewCredit.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+
+Map<String, dynamic> _$CombinedCreditsToJson(CombinedCredits instance) =>
+    <String, dynamic>{
+      'cast': instance.cast.map((e) => e.toJson()).toList(),
+      'crew': instance.crew.map((e) => e.toJson()).toList(),
+    };
+
+ActorCastCredit _$ActorCastCreditFromJson(Map<String, dynamic> json) =>
+    ActorCastCredit(
+      adult: json['adult'] as bool?,
+      backdropPath: json['backdrop_path'] as String?,
+      character: json['character'] as String?,
+      creditId: json['credit_id'] as String?,
+      episodeCount: (json['episode_count'] as num?)?.toInt(),
+      firstAirDate: json['first_air_date'] as String?,
+      genreIds: (json['genre_ids'] as List<dynamic>?)
+          ?.map((e) => (e as num).toInt())
+          .toList(),
+      id: (json['id'] as num?)?.toInt(),
+      mediaType: json['media_type'] as String?,
+      name: json['name'] as String?,
+      originCountry: (json['origin_country'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      originalLanguage: json['original_language'] as String?,
+      originalName: json['original_name'] as String?,
+      originalTitle: json['original_title'] as String?,
+      overview: json['overview'] as String?,
+      popularity: (json['popularity'] as num?)?.toDouble(),
+      posterPath: json['poster_path'] as String?,
+      releaseDate: json['release_date'] as String?,
+      title: json['title'] as String?,
+      video: json['video'] as bool?,
+      voteAverage: (json['vote_average'] as num?)?.toDouble(),
+      voteCount: (json['vote_count'] as num?)?.toInt(),
+      order: (json['order'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$ActorCastCreditToJson(ActorCastCredit instance) =>
+    <String, dynamic>{
+      'adult': instance.adult,
+      'backdrop_path': instance.backdropPath,
+      'character': instance.character,
+      'credit_id': instance.creditId,
+      'episode_count': instance.episodeCount,
+      'first_air_date': instance.firstAirDate,
+      'genre_ids': instance.genreIds,
+      'id': instance.id,
+      'media_type': instance.mediaType,
+      'name': instance.name,
+      'origin_country': instance.originCountry,
+      'original_language': instance.originalLanguage,
+      'original_name': instance.originalName,
+      'original_title': instance.originalTitle,
+      'overview': instance.overview,
+      'popularity': instance.popularity,
+      'poster_path': instance.posterPath,
+      'release_date': instance.releaseDate,
+      'title': instance.title,
+      'video': instance.video,
+      'vote_average': instance.voteAverage,
+      'vote_count': instance.voteCount,
+      'order': instance.order,
+    };
+
+ActorCrewCredit _$ActorCrewCreditFromJson(Map<String, dynamic> json) =>
+    ActorCrewCredit(
+      adult: json['adult'] as bool?,
+      backdropPath: json['backdrop_path'] as String?,
+      creditId: json['credit_id'] as String?,
+      department: json['department'] as String?,
+      episodeCount: (json['episode_count'] as num?)?.toInt(),
+      firstAirDate: json['first_air_date'] as String?,
+      genreIds: (json['genre_ids'] as List<dynamic>?)
+          ?.map((e) => (e as num).toInt())
+          .toList(),
+      id: (json['id'] as num?)?.toInt(),
+      job: json['job'] as String?,
+      mediaType: json['media_type'] as String?,
+      name: json['name'] as String?,
+      originCountry: (json['origin_country'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      originalLanguage: json['original_language'] as String?,
+      originalName: json['original_name'] as String?,
+      originalTitle: json['original_title'] as String?,
+      overview: json['overview'] as String?,
+      popularity: (json['popularity'] as num?)?.toDouble(),
+      posterPath: json['poster_path'] as String?,
+      releaseDate: json['release_date'] as String?,
+      title: json['title'] as String?,
+      video: json['video'] as bool?,
+      voteAverage: (json['vote_average'] as num?)?.toDouble(),
+      voteCount: (json['vote_count'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$ActorCrewCreditToJson(ActorCrewCredit instance) =>
+    <String, dynamic>{
+      'adult': instance.adult,
+      'backdrop_path': instance.backdropPath,
+      'credit_id': instance.creditId,
+      'department': instance.department,
+      'episode_count': instance.episodeCount,
+      'first_air_date': instance.firstAirDate,
+      'genre_ids': instance.genreIds,
+      'id': instance.id,
+      'job': instance.job,
+      'media_type': instance.mediaType,
+      'name': instance.name,
+      'origin_country': instance.originCountry,
+      'original_language': instance.originalLanguage,
+      'original_name': instance.originalName,
+      'original_title': instance.originalTitle,
+      'overview': instance.overview,
+      'popularity': instance.popularity,
+      'poster_path': instance.posterPath,
+      'release_date': instance.releaseDate,
+      'title': instance.title,
+      'video': instance.video,
+      'vote_average': instance.voteAverage,
+      'vote_count': instance.voteCount,
+    };

--- a/lib/features/actors/domain/repositories/actors_repository.dart
+++ b/lib/features/actors/domain/repositories/actors_repository.dart
@@ -1,8 +1,15 @@
+import '../models/actor_details.dart';
 import '../models/actors_list_entity.dart';
 
 abstract class ActorsRepository {
   Future<ActorsListEntity> getPopularActors(
     int page,
+    String apiKey,
+    String language,
+  );
+
+  Future<ActorDetails> getActorDetails(
+    int actorId,
     String apiKey,
     String language,
   );

--- a/lib/features/actors/domain/usecases/details/actor_details_use_case.dart
+++ b/lib/features/actors/domain/usecases/details/actor_details_use_case.dart
@@ -1,0 +1,9 @@
+import '../../models/actor_details.dart';
+
+abstract class ActorDetailsUseCase {
+  Future<ActorDetails> getActorDetails(
+    int actorId,
+    String apiKey,
+    String language,
+  );
+}

--- a/lib/features/actors/domain/usecases/details/actor_details_use_case_impl.dart
+++ b/lib/features/actors/domain/usecases/details/actor_details_use_case_impl.dart
@@ -1,0 +1,18 @@
+import '../../models/actor_details.dart';
+import '../../repositories/actors_repository.dart';
+import 'actor_details_use_case.dart';
+
+class ActorDetailsUseCaseImpl extends ActorDetailsUseCase {
+  ActorDetailsUseCaseImpl({required this.repository});
+
+  final ActorsRepository repository;
+
+  @override
+  Future<ActorDetails> getActorDetails(
+    int actorId,
+    String apiKey,
+    String language,
+  ) {
+    return repository.getActorDetails(actorId, apiKey, language);
+  }
+}

--- a/lib/features/actors/domain/usecases/usecases.dart
+++ b/lib/features/actors/domain/usecases/usecases.dart
@@ -1,2 +1,4 @@
 export 'package:tmdb_flutter_app/features/actors/domain/usecases/popular/popular_actors_use_case.dart';
 export 'package:tmdb_flutter_app/features/actors/domain/usecases/popular/popular_actors_use_case_impl.dart';
+export 'package:tmdb_flutter_app/features/actors/domain/usecases/details/actor_details_use_case.dart';
+export 'package:tmdb_flutter_app/features/actors/domain/usecases/details/actor_details_use_case_impl.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -133,6 +133,12 @@ Future<void> main() async {
       ),
     );
 
+    di.registerLazySingleton<ActorDetailsUseCase>(
+      () => ActorDetailsUseCaseImpl(
+        repository: di.get<ActorsRepository>(),
+      ),
+    );
+
     FlutterError.onError = (details) =>
         di<Talker>().handle(details.exception, details.stack);
 


### PR DESCRIPTION
## Summary
- add an `ActorDetails` domain model (with generated serialization) that mirrors `/person/{id}` fields including combined credits
- extend the actors repository plus a new `ActorDetailsUseCase` to expose person details fetching
- register the new use case with GetIt so the data can be consumed throughout the app

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs` *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dee87e7aac83239735dc3882954703