### PR TITLE
Refactor actor details events to use dedicated base class

### DIFF
--- a/lib/features/actors/presentation/bloc/actor_details_event.dart
+++ b/lib/features/actors/presentation/bloc/actor_details_event.dart
@@ -1,6 +1,10 @@
 part of 'actor_details_bloc.dart';
 
-class LoadActorDetails extends UiEvent {
+abstract class ActorDetailsEvent extends UiEvent {
+  const ActorDetailsEvent();
+}
+
+class LoadActorDetails extends ActorDetailsEvent {
   LoadActorDetails({required this.actorId, this.language});
 
   final int actorId;


### PR DESCRIPTION
## Summary
- introduce an `ActorDetailsEvent` abstract base class for the actor details bloc
- update `LoadActorDetails` to extend the new base class while keeping existing props

## Testing
- flutter analyze *(fails: Flutter SDK not available in environment)*
- flutter test test/features/actors/presentation/bloc/actor_details_bloc_test.dart *(fails: Flutter SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68def94eef9c8323a391be8801f74abf