### PR TITLE
Add splash screen bootstrap for TMDB auth flow

### DIFF
--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -12,7 +12,10 @@ class AppRouter extends _$AppRouter {
 
   @override
   List<AutoRoute> get routes => [
-    AutoRoute(page: MainHomeRoute.page, initial: true),
+    AutoRoute(page: SplashRoute.page, initial: true),
+    AutoRoute(page: SignInRoute.page),
+    AutoRoute(page: RegisterRoute.page),
+    AutoRoute(page: MainHomeRoute.page),
     AutoRoute(page: MoviesRoute.page),
     AutoRoute(page: MovieDetailsRoute.page),
     AutoRoute(page: ActorDetailsRoute.page),

--- a/lib/core/router/router.gr.dart
+++ b/lib/core/router/router.gr.dart
@@ -67,10 +67,28 @@ abstract class _$AppRouter extends RootStackRouter {
         child: const ProfileScreen(),
       );
     },
+    RegisterRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const RegisterScreen(),
+      );
+    },
     SearchRoute.name: (routeData) {
       return AutoRoutePage<dynamic>(
         routeData: routeData,
         child: const SearchScreen(),
+      );
+    },
+    SignInRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const SignInScreen(),
+      );
+    },
+    SplashRoute.name: (routeData) {
+      return AutoRoutePage<dynamic>(
+        routeData: routeData,
+        child: const SplashScreen(),
       );
     },
     TvShowsRoute.name: (routeData) {
@@ -239,6 +257,20 @@ class ProfileRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
+/// [RegisterScreen]
+class RegisterRoute extends PageRouteInfo<void> {
+  const RegisterRoute({List<PageRouteInfo>? children})
+      : super(
+          RegisterRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'RegisterRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
 /// [SearchScreen]
 class SearchRoute extends PageRouteInfo<void> {
   const SearchRoute({List<PageRouteInfo>? children})
@@ -248,6 +280,34 @@ class SearchRoute extends PageRouteInfo<void> {
         );
 
   static const String name = 'SearchRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [SignInScreen]
+class SignInRoute extends PageRouteInfo<void> {
+  const SignInRoute({List<PageRouteInfo>? children})
+      : super(
+          SignInRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SignInRoute';
+
+  static const PageInfo<void> page = PageInfo<void>(name);
+}
+
+/// generated route for
+/// [SplashScreen]
+class SplashRoute extends PageRouteInfo<void> {
+  const SplashRoute({List<PageRouteInfo>? children})
+      : super(
+          SplashRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SplashRoute';
 
   static const PageInfo<void> page = PageInfo<void>(name);
 }

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -1,0 +1,16 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+
+@RoutePage()
+class RegisterScreen extends StatelessWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Register'),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/screens/sign_in_screen.dart
+++ b/lib/features/auth/presentation/screens/sign_in_screen.dart
@@ -1,0 +1,16 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+
+@RoutePage()
+class SignInScreen extends StatelessWidget {
+  const SignInScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Sign In'),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/screens/splash_screen.dart
+++ b/lib/features/auth/presentation/screens/splash_screen.dart
@@ -1,0 +1,80 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+import '../../../../core/router/router.dart';
+
+@RoutePage()
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _bootstrap());
+  }
+
+  Future<void> _bootstrap() async {
+    try {
+      if (!dotenv.isInitialized) {
+        await dotenv.load(fileName: 'tmdb_app_properties.env');
+      }
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Failed to load TMDB configuration: $error');
+      }
+    }
+
+    final apiKey = dotenv.env['PERSONAL_TMDB_API_KEY'];
+    final hasApiKey = apiKey != null && apiKey.isNotEmpty;
+    final sessionId = dotenv.env['TMDB_SESSION_ID'] ?? '';
+    final accessToken = dotenv.env['TMDB_ACCESS_TOKEN'] ?? '';
+    final isAuthenticated = sessionId.isNotEmpty || accessToken.isNotEmpty;
+
+    if (!mounted) return;
+
+    final router = context.router;
+
+    if (!hasApiKey) {
+      router.replaceAll([const RegisterRoute()]);
+      return;
+    }
+
+    if (isAuthenticated) {
+      router.replaceAll([const MainHomeRoute()]);
+    } else {
+      router.replaceAll([const SignInRoute()]);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(
+              height: 64,
+              width: 64,
+              child: CircularProgressIndicator(),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Preparing TMDB experience…',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/screens.dart
+++ b/lib/features/screens.dart
@@ -8,3 +8,6 @@ export '../features/tv_shows/presentation/screens/tv_shows_screen.dart';
 export '../features/search/presentation/screens/search_screen.dart';
 export '../features/actors/presentation/screens/actors_screen.dart';
 export '../features/actors/presentation/screens/actor_details_screen.dart';
+export '../features/auth/presentation/screens/splash_screen.dart';
+export '../features/auth/presentation/screens/sign_in_screen.dart';
+export '../features/auth/presentation/screens/register_screen.dart';


### PR DESCRIPTION
## Summary
- add a splash screen that loads TMDB configuration and redirects to auth or home
- register splash, sign-in, and register routes with the app router and export the new screens
- scaffold placeholder sign-in and register screens so navigation targets exist

## Testing
- `flutter pub run build_runner build` *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e18c0cfb408323a8ce182ad459753e