### PR TITLE
Refine movie details hero and summary layout

### DIFF
--- a/lib/features/movies/domain/models/movie.dart
+++ b/lib/features/movies/domain/models/movie.dart
@@ -20,6 +20,7 @@ class Movie extends Equatable {
     required this.video,
     required this.voteAverage,
     required this.voteCount,
+    required this.runtime,
   });
 
   final bool? adult;
@@ -44,6 +45,7 @@ class Movie extends Equatable {
   final double? voteAverage;
   @JsonKey(name: "vote_count")
   final int? voteCount;
+  final int? runtime;
 
   @override
   List<Object?> get props => [
@@ -61,6 +63,7 @@ class Movie extends Equatable {
     video,
     voteAverage,
     voteCount,
+    runtime,
   ];
 
   factory Movie.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/movies/domain/models/movie.g.dart
+++ b/lib/features/movies/domain/models/movie.g.dart
@@ -23,6 +23,7 @@ Movie _$MovieFromJson(Map<String, dynamic> json) => Movie(
       video: json['video'] as bool?,
       voteAverage: (json['vote_average'] as num?)?.toDouble(),
       voteCount: (json['vote_count'] as num?)?.toInt(),
+      runtime: (json['runtime'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$MovieToJson(Movie instance) => <String, dynamic>{
@@ -40,4 +41,5 @@ Map<String, dynamic> _$MovieToJson(Movie instance) => <String, dynamic>{
       'video': instance.video,
       'vote_average': instance.voteAverage,
       'vote_count': instance.voteCount,
+      'runtime': instance.runtime,
     };


### PR DESCRIPTION
## Summary
- redesign the movie details hero with a stacked backdrop, gradient, and Watch Providers call-to-action
- rework the summary row to align the poster, metadata, user score indicator, and rate button while handling missing artwork
- add runtime support to the Movie model and surface runtime-aware chips/details when data exists

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1964f5f548323b15ed6f71904bab1