### PR TITLE
Add movie detail data flow and UI updates

### DIFF
--- a/lib/features/movies/domain/models/genre.dart
+++ b/lib/features/movies/domain/models/genre.dart
@@ -1,0 +1,22 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'genre.g.dart';
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class Genre extends Equatable {
+  const Genre({
+    required this.id,
+    required this.name,
+  });
+
+  final int? id;
+  final String? name;
+
+  @override
+  List<Object?> get props => [id, name];
+
+  factory Genre.fromJson(Map<String, dynamic> json) => _$GenreFromJson(json);
+
+  Map<String, dynamic> toJson() => _$GenreToJson(this);
+}

--- a/lib/features/movies/domain/models/genre.g.dart
+++ b/lib/features/movies/domain/models/genre.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'genre.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Genre _$GenreFromJson(Map<String, dynamic> json) => Genre(
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String?,
+    );
+
+Map<String, dynamic> _$GenreToJson(Genre instance) => <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+    };

--- a/lib/features/movies/domain/models/movie_credit.dart
+++ b/lib/features/movies/domain/models/movie_credit.dart
@@ -1,0 +1,54 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'movie_credit.g.dart';
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MovieCredit extends Equatable {
+  const MovieCredit({
+    required this.creditId,
+    required this.id,
+    required this.name,
+    required this.originalName,
+    required this.profilePath,
+    required this.character,
+    required this.job,
+    required this.department,
+    required this.knownForDepartment,
+    required this.order,
+  });
+
+  final String? creditId;
+  final int? id;
+  final String? name;
+  final String? originalName;
+  final String? profilePath;
+  final String? character;
+  final String? job;
+  final String? department;
+  final String? knownForDepartment;
+  final int? order;
+
+  bool get isCast => character != null && character!.isNotEmpty;
+
+  String? get role => character?.isNotEmpty == true ? character : job;
+
+  @override
+  List<Object?> get props => [
+        creditId,
+        id,
+        name,
+        originalName,
+        profilePath,
+        character,
+        job,
+        department,
+        knownForDepartment,
+        order,
+      ];
+
+  factory MovieCredit.fromJson(Map<String, dynamic> json) =>
+      _$MovieCreditFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MovieCreditToJson(this);
+}

--- a/lib/features/movies/domain/models/movie_credit.g.dart
+++ b/lib/features/movies/domain/models/movie_credit.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'movie_credit.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MovieCredit _$MovieCreditFromJson(Map<String, dynamic> json) => MovieCredit(
+      creditId: json['credit_id'] as String?,
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String?,
+      originalName: json['original_name'] as String?,
+      profilePath: json['profile_path'] as String?,
+      character: json['character'] as String?,
+      job: json['job'] as String?,
+      department: json['department'] as String?,
+      knownForDepartment: json['known_for_department'] as String?,
+      order: (json['order'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$MovieCreditToJson(MovieCredit instance) =>
+    <String, dynamic>{
+      'credit_id': instance.creditId,
+      'id': instance.id,
+      'name': instance.name,
+      'original_name': instance.originalName,
+      'profile_path': instance.profilePath,
+      'character': instance.character,
+      'job': instance.job,
+      'department': instance.department,
+      'known_for_department': instance.knownForDepartment,
+      'order': instance.order,
+    };

--- a/lib/features/movies/domain/models/movie_credits.dart
+++ b/lib/features/movies/domain/models/movie_credits.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import 'movie_credit.dart';
+
+part 'movie_credits.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class MovieCredits extends Equatable {
+  const MovieCredits({
+    required this.id,
+    required this.cast,
+    required this.crew,
+  });
+
+  final int? id;
+  @JsonKey(defaultValue: <MovieCredit>[])
+  final List<MovieCredit> cast;
+  @JsonKey(defaultValue: <MovieCredit>[])
+  final List<MovieCredit> crew;
+
+  @override
+  List<Object?> get props => [id, cast, crew];
+
+  factory MovieCredits.fromJson(Map<String, dynamic> json) =>
+      _$MovieCreditsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MovieCreditsToJson(this);
+}

--- a/lib/features/movies/domain/models/movie_credits.g.dart
+++ b/lib/features/movies/domain/models/movie_credits.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'movie_credits.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MovieCredits _$MovieCreditsFromJson(Map<String, dynamic> json) => MovieCredits(
+      id: (json['id'] as num?)?.toInt(),
+      cast: (json['cast'] as List<dynamic>?)
+              ?.map((e) => MovieCredit.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <MovieCredit>[],
+      crew: (json['crew'] as List<dynamic>?)
+              ?.map((e) => MovieCredit.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <MovieCredit>[],
+    );
+
+Map<String, dynamic> _$MovieCreditsToJson(MovieCredits instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'cast': instance.cast.map((e) => e.toJson()).toList(),
+      'crew': instance.crew.map((e) => e.toJson()).toList(),
+    };

--- a/lib/features/movies/domain/models/movie_detail.dart
+++ b/lib/features/movies/domain/models/movie_detail.dart
@@ -1,0 +1,71 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import 'genre.dart';
+
+part 'movie_detail.g.dart';
+
+@JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
+class MovieDetail extends Equatable {
+  const MovieDetail({
+    required this.id,
+    required this.title,
+    required this.originalTitle,
+    required this.overview,
+    required this.tagline,
+    required this.runtime,
+    required this.releaseDate,
+    required this.status,
+    required this.backdropPath,
+    required this.posterPath,
+    required this.voteAverage,
+    required this.voteCount,
+    required this.genres,
+    required this.homepage,
+    required this.originalLanguage,
+    required this.popularity,
+  });
+
+  final int? id;
+  final String? title;
+  final String? originalTitle;
+  final String? overview;
+  final String? tagline;
+  final int? runtime;
+  final String? releaseDate;
+  final String? status;
+  final String? backdropPath;
+  final String? posterPath;
+  final double? voteAverage;
+  final int? voteCount;
+  @JsonKey(defaultValue: <Genre>[])
+  final List<Genre> genres;
+  final String? homepage;
+  final String? originalLanguage;
+  final double? popularity;
+
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        originalTitle,
+        overview,
+        tagline,
+        runtime,
+        releaseDate,
+        status,
+        backdropPath,
+        posterPath,
+        voteAverage,
+        voteCount,
+        genres,
+        homepage,
+        originalLanguage,
+        popularity,
+      ];
+
+  factory MovieDetail.fromJson(Map<String, dynamic> json) =>
+      _$MovieDetailFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MovieDetailToJson(this);
+}

--- a/lib/features/movies/domain/models/movie_detail.g.dart
+++ b/lib/features/movies/domain/models/movie_detail.g.dart
@@ -1,0 +1,49 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'movie_detail.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MovieDetail _$MovieDetailFromJson(Map<String, dynamic> json) => MovieDetail(
+      id: (json['id'] as num?)?.toInt(),
+      title: json['title'] as String?,
+      originalTitle: json['original_title'] as String?,
+      overview: json['overview'] as String?,
+      tagline: json['tagline'] as String?,
+      runtime: (json['runtime'] as num?)?.toInt(),
+      releaseDate: json['release_date'] as String?,
+      status: json['status'] as String?,
+      backdropPath: json['backdrop_path'] as String?,
+      posterPath: json['poster_path'] as String?,
+      voteAverage: (json['vote_average'] as num?)?.toDouble(),
+      voteCount: (json['vote_count'] as num?)?.toInt(),
+      genres: (json['genres'] as List<dynamic>?)
+              ?.map((e) => Genre.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <Genre>[],
+      homepage: json['homepage'] as String?,
+      originalLanguage: json['original_language'] as String?,
+      popularity: (json['popularity'] as num?)?.toDouble(),
+    );
+
+Map<String, dynamic> _$MovieDetailToJson(MovieDetail instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'original_title': instance.originalTitle,
+      'overview': instance.overview,
+      'tagline': instance.tagline,
+      'runtime': instance.runtime,
+      'release_date': instance.releaseDate,
+      'status': instance.status,
+      'backdrop_path': instance.backdropPath,
+      'poster_path': instance.posterPath,
+      'vote_average': instance.voteAverage,
+      'vote_count': instance.voteCount,
+      'genres': instance.genres.map((e) => e.toJson()).toList(),
+      'homepage': instance.homepage,
+      'original_language': instance.originalLanguage,
+      'popularity': instance.popularity,
+    };

--- a/lib/features/movies/domain/models/movie_recommendation.dart
+++ b/lib/features/movies/domain/models/movie_recommendation.dart
@@ -1,0 +1,41 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'movie_recommendation.g.dart';
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MovieRecommendation extends Equatable {
+  const MovieRecommendation({
+    required this.id,
+    required this.title,
+    required this.originalTitle,
+    required this.posterPath,
+    required this.backdropPath,
+    required this.voteAverage,
+    required this.releaseDate,
+  });
+
+  final int? id;
+  final String? title;
+  final String? originalTitle;
+  final String? posterPath;
+  final String? backdropPath;
+  final double? voteAverage;
+  final String? releaseDate;
+
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        originalTitle,
+        posterPath,
+        backdropPath,
+        voteAverage,
+        releaseDate,
+      ];
+
+  factory MovieRecommendation.fromJson(Map<String, dynamic> json) =>
+      _$MovieRecommendationFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MovieRecommendationToJson(this);
+}

--- a/lib/features/movies/domain/models/movie_recommendation.g.dart
+++ b/lib/features/movies/domain/models/movie_recommendation.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'movie_recommendation.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MovieRecommendation _$MovieRecommendationFromJson(
+        Map<String, dynamic> json) =>
+    MovieRecommendation(
+      id: (json['id'] as num?)?.toInt(),
+      title: json['title'] as String?,
+      originalTitle: json['original_title'] as String?,
+      posterPath: json['poster_path'] as String?,
+      backdropPath: json['backdrop_path'] as String?,
+      voteAverage: (json['vote_average'] as num?)?.toDouble(),
+      releaseDate: json['release_date'] as String?,
+    );
+
+Map<String, dynamic> _$MovieRecommendationToJson(
+        MovieRecommendation instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'original_title': instance.originalTitle,
+      'poster_path': instance.posterPath,
+      'backdrop_path': instance.backdropPath,
+      'vote_average': instance.voteAverage,
+      'release_date': instance.releaseDate,
+    };

--- a/lib/features/movies/domain/models/movie_recommendations.dart
+++ b/lib/features/movies/domain/models/movie_recommendations.dart
@@ -1,0 +1,30 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import 'movie_recommendation.dart';
+
+part 'movie_recommendations.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class MovieRecommendations extends Equatable {
+  const MovieRecommendations({
+    required this.page,
+    required this.results,
+    required this.totalPages,
+    required this.totalResults,
+  });
+
+  final int? page;
+  @JsonKey(defaultValue: <MovieRecommendation>[])
+  final List<MovieRecommendation> results;
+  final int? totalPages;
+  final int? totalResults;
+
+  @override
+  List<Object?> get props => [page, results, totalPages, totalResults];
+
+  factory MovieRecommendations.fromJson(Map<String, dynamic> json) =>
+      _$MovieRecommendationsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MovieRecommendationsToJson(this);
+}

--- a/lib/features/movies/domain/models/movie_recommendations.g.dart
+++ b/lib/features/movies/domain/models/movie_recommendations.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'movie_recommendations.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MovieRecommendations _$MovieRecommendationsFromJson(
+        Map<String, dynamic> json) =>
+    MovieRecommendations(
+      page: (json['page'] as num?)?.toInt(),
+      results: (json['results'] as List<dynamic>?)
+              ?.map((e) =>
+                  MovieRecommendation.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <MovieRecommendation>[],
+      totalPages: (json['total_pages'] as num?)?.toInt(),
+      totalResults: (json['total_results'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$MovieRecommendationsToJson(
+        MovieRecommendations instance) =>
+    <String, dynamic>{
+      'page': instance.page,
+      'results': instance.results.map((e) => e.toJson()).toList(),
+      'total_pages': instance.totalPages,
+      'total_results': instance.totalResults,
+    };

--- a/lib/features/movies/domain/models/movie_review.dart
+++ b/lib/features/movies/domain/models/movie_review.dart
@@ -1,0 +1,41 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'movie_review.g.dart';
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class MovieReview extends Equatable {
+  const MovieReview({
+    required this.id,
+    required this.author,
+    required this.authorDetails,
+    required this.content,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.url,
+  });
+
+  final String? id;
+  final String? author;
+  final Map<String, dynamic>? authorDetails;
+  final String? content;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final String? url;
+
+  @override
+  List<Object?> get props => [
+        id,
+        author,
+        authorDetails,
+        content,
+        createdAt,
+        updatedAt,
+        url,
+      ];
+
+  factory MovieReview.fromJson(Map<String, dynamic> json) =>
+      _$MovieReviewFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MovieReviewToJson(this);
+}

--- a/lib/features/movies/domain/models/movie_review.g.dart
+++ b/lib/features/movies/domain/models/movie_review.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'movie_review.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MovieReview _$MovieReviewFromJson(Map<String, dynamic> json) => MovieReview(
+      id: json['id'] as String?,
+      author: json['author'] as String?,
+      authorDetails: json['author_details'] as Map<String, dynamic>?,
+      content: json['content'] as String?,
+      createdAt: json['created_at'] == null
+          ? null
+          : DateTime.parse(json['created_at'] as String),
+      updatedAt: json['updated_at'] == null
+          ? null
+          : DateTime.parse(json['updated_at'] as String),
+      url: json['url'] as String?,
+    );
+
+Map<String, dynamic> _$MovieReviewToJson(MovieReview instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'author': instance.author,
+      'author_details': instance.authorDetails,
+      'content': instance.content,
+      'created_at': instance.createdAt?.toIso8601String(),
+      'updated_at': instance.updatedAt?.toIso8601String(),
+      'url': instance.url,
+    };

--- a/lib/features/movies/domain/models/movie_reviews.dart
+++ b/lib/features/movies/domain/models/movie_reviews.dart
@@ -1,0 +1,38 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import 'movie_review.dart';
+
+part 'movie_reviews.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class MovieReviews extends Equatable {
+  const MovieReviews({
+    required this.id,
+    required this.page,
+    required this.results,
+    required this.totalPages,
+    required this.totalResults,
+  });
+
+  final int? id;
+  final int? page;
+  @JsonKey(defaultValue: <MovieReview>[])
+  final List<MovieReview> results;
+  final int? totalPages;
+  final int? totalResults;
+
+  @override
+  List<Object?> get props => [
+        id,
+        page,
+        results,
+        totalPages,
+        totalResults,
+      ];
+
+  factory MovieReviews.fromJson(Map<String, dynamic> json) =>
+      _$MovieReviewsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MovieReviewsToJson(this);
+}

--- a/lib/features/movies/domain/models/movie_reviews.g.dart
+++ b/lib/features/movies/domain/models/movie_reviews.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'movie_reviews.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MovieReviews _$MovieReviewsFromJson(Map<String, dynamic> json) => MovieReviews(
+      id: (json['id'] as num?)?.toInt(),
+      page: (json['page'] as num?)?.toInt(),
+      results: (json['results'] as List<dynamic>?)
+              ?.map((e) => MovieReview.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <MovieReview>[],
+      totalPages: (json['total_pages'] as num?)?.toInt(),
+      totalResults: (json['total_results'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$MovieReviewsToJson(MovieReviews instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'page': instance.page,
+      'results': instance.results.map((e) => e.toJson()).toList(),
+      'total_pages': instance.totalPages,
+      'total_results': instance.totalResults,
+    };

--- a/lib/features/movies/domain/models/movie_watch_providers.dart
+++ b/lib/features/movies/domain/models/movie_watch_providers.dart
@@ -1,0 +1,53 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import 'watch_provider.dart';
+
+part 'movie_watch_providers.g.dart';
+
+@JsonSerializable(explicitToJson: true, fieldRename: FieldRename.snake)
+class MovieWatchProviders extends Equatable {
+  const MovieWatchProviders({
+    required this.link,
+    required this.flatrate,
+    required this.rent,
+    required this.buy,
+    required this.ads,
+    required this.free,
+  });
+
+  const MovieWatchProviders.empty()
+      : link = null,
+        flatrate = const [],
+        rent = const [],
+        buy = const [],
+        ads = const [],
+        free = const [];
+
+  final String? link;
+  @JsonKey(defaultValue: <WatchProvider>[])
+  final List<WatchProvider> flatrate;
+  @JsonKey(defaultValue: <WatchProvider>[])
+  final List<WatchProvider> rent;
+  @JsonKey(defaultValue: <WatchProvider>[])
+  final List<WatchProvider> buy;
+  @JsonKey(defaultValue: <WatchProvider>[])
+  final List<WatchProvider> ads;
+  @JsonKey(defaultValue: <WatchProvider>[])
+  final List<WatchProvider> free;
+
+  bool get hasAnyProviders =>
+      flatrate.isNotEmpty ||
+      rent.isNotEmpty ||
+      buy.isNotEmpty ||
+      ads.isNotEmpty ||
+      free.isNotEmpty;
+
+  @override
+  List<Object?> get props => [link, flatrate, rent, buy, ads, free];
+
+  factory MovieWatchProviders.fromJson(Map<String, dynamic> json) =>
+      _$MovieWatchProvidersFromJson(json);
+
+  Map<String, dynamic> toJson() => _$MovieWatchProvidersToJson(this);
+}

--- a/lib/features/movies/domain/models/movie_watch_providers.g.dart
+++ b/lib/features/movies/domain/models/movie_watch_providers.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'movie_watch_providers.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MovieWatchProviders _$MovieWatchProvidersFromJson(Map<String, dynamic> json) =>
+    MovieWatchProviders(
+      link: json['link'] as String?,
+      flatrate: (json['flatrate'] as List<dynamic>?)
+              ?.map((e) => WatchProvider.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <WatchProvider>[],
+      rent: (json['rent'] as List<dynamic>?)
+              ?.map((e) => WatchProvider.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <WatchProvider>[],
+      buy: (json['buy'] as List<dynamic>?)
+              ?.map((e) => WatchProvider.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <WatchProvider>[],
+      ads: (json['ads'] as List<dynamic>?)
+              ?.map((e) => WatchProvider.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <WatchProvider>[],
+      free: (json['free'] as List<dynamic>?)
+              ?.map((e) => WatchProvider.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <WatchProvider>[],
+    );
+
+Map<String, dynamic> _$MovieWatchProvidersToJson(
+        MovieWatchProviders instance) =>
+    <String, dynamic>{
+      'link': instance.link,
+      'flatrate': instance.flatrate.map((e) => e.toJson()).toList(),
+      'rent': instance.rent.map((e) => e.toJson()).toList(),
+      'buy': instance.buy.map((e) => e.toJson()).toList(),
+      'ads': instance.ads.map((e) => e.toJson()).toList(),
+      'free': instance.free.map((e) => e.toJson()).toList(),
+    };

--- a/lib/features/movies/domain/models/watch_provider.dart
+++ b/lib/features/movies/domain/models/watch_provider.dart
@@ -1,0 +1,27 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'watch_provider.g.dart';
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class WatchProvider extends Equatable {
+  const WatchProvider({
+    required this.providerId,
+    required this.providerName,
+    required this.logoPath,
+    required this.displayPriority,
+  });
+
+  final int? providerId;
+  final String? providerName;
+  final String? logoPath;
+  final int? displayPriority;
+
+  @override
+  List<Object?> get props => [providerId, providerName, logoPath, displayPriority];
+
+  factory WatchProvider.fromJson(Map<String, dynamic> json) =>
+      _$WatchProviderFromJson(json);
+
+  Map<String, dynamic> toJson() => _$WatchProviderToJson(this);
+}

--- a/lib/features/movies/domain/models/watch_provider.g.dart
+++ b/lib/features/movies/domain/models/watch_provider.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'watch_provider.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+WatchProvider _$WatchProviderFromJson(Map<String, dynamic> json) => WatchProvider(
+      providerId: (json['provider_id'] as num?)?.toInt(),
+      providerName: json['provider_name'] as String?,
+      logoPath: json['logo_path'] as String?,
+      displayPriority: (json['display_priority'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$WatchProviderToJson(WatchProvider instance) =>
+    <String, dynamic>{
+      'provider_id': instance.providerId,
+      'provider_name': instance.providerName,
+      'logo_path': instance.logoPath,
+      'display_priority': instance.displayPriority,
+    };

--- a/lib/features/movies/domain/repositories/movie_repository.dart
+++ b/lib/features/movies/domain/repositories/movie_repository.dart
@@ -1,3 +1,8 @@
+import 'package:tmdb_flutter_app/features/movies/domain/models/movie_credits.dart';
+import 'package:tmdb_flutter_app/features/movies/domain/models/movie_detail.dart';
+import 'package:tmdb_flutter_app/features/movies/domain/models/movie_recommendations.dart';
+import 'package:tmdb_flutter_app/features/movies/domain/models/movie_reviews.dart';
+import 'package:tmdb_flutter_app/features/movies/domain/models/movie_watch_providers.dart';
 import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dart';
 
 abstract class MovieRepository {
@@ -35,4 +40,34 @@ abstract class MovieRepository {
       String region,
       String language,
       );
+
+  Future<MovieDetail> getMovieDetails(
+    int movieId,
+    String apiKey,
+    String language,
+  );
+
+  Future<MovieCredits> getMovieCredits(
+    int movieId,
+    String apiKey,
+    String language,
+  );
+
+  Future<MovieReviews> getMovieReviews(
+    int movieId,
+    String apiKey,
+    String language,
+  );
+
+  Future<MovieRecommendations> getMovieRecommendations(
+    int movieId,
+    String apiKey,
+    String language,
+  );
+
+  Future<MovieWatchProviders> getMovieWatchProviders(
+    int movieId,
+    String apiKey,
+    String region,
+  );
 }

--- a/lib/features/movies/domain/usecases/details/movie_credits_use_case.dart
+++ b/lib/features/movies/domain/usecases/details/movie_credits_use_case.dart
@@ -1,0 +1,9 @@
+import '../../models/movie_credits.dart';
+
+abstract class MovieCreditsUseCase {
+  Future<MovieCredits> getMovieCredits(
+    int movieId,
+    String apiKey,
+    String language,
+  );
+}

--- a/lib/features/movies/domain/usecases/details/movie_credits_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/details/movie_credits_use_case_impl.dart
@@ -1,0 +1,18 @@
+import '../../models/movie_credits.dart';
+import '../../repositories/movie_repository.dart';
+import 'movie_credits_use_case.dart';
+
+class MovieCreditsUseCaseImpl extends MovieCreditsUseCase {
+  MovieCreditsUseCaseImpl({required this.repository});
+
+  final MovieRepository repository;
+
+  @override
+  Future<MovieCredits> getMovieCredits(
+    int movieId,
+    String apiKey,
+    String language,
+  ) {
+    return repository.getMovieCredits(movieId, apiKey, language);
+  }
+}

--- a/lib/features/movies/domain/usecases/details/movie_details_use_case.dart
+++ b/lib/features/movies/domain/usecases/details/movie_details_use_case.dart
@@ -1,0 +1,9 @@
+import '../../models/movie_detail.dart';
+
+abstract class MovieDetailsUseCase {
+  Future<MovieDetail> getMovieDetails(
+    int movieId,
+    String apiKey,
+    String language,
+  );
+}

--- a/lib/features/movies/domain/usecases/details/movie_details_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/details/movie_details_use_case_impl.dart
@@ -1,0 +1,18 @@
+import '../../models/movie_detail.dart';
+import '../../repositories/movie_repository.dart';
+import 'movie_details_use_case.dart';
+
+class MovieDetailsUseCaseImpl extends MovieDetailsUseCase {
+  MovieDetailsUseCaseImpl({required this.repository});
+
+  final MovieRepository repository;
+
+  @override
+  Future<MovieDetail> getMovieDetails(
+    int movieId,
+    String apiKey,
+    String language,
+  ) {
+    return repository.getMovieDetails(movieId, apiKey, language);
+  }
+}

--- a/lib/features/movies/domain/usecases/details/movie_recommendations_use_case.dart
+++ b/lib/features/movies/domain/usecases/details/movie_recommendations_use_case.dart
@@ -1,0 +1,9 @@
+import '../../models/movie_recommendations.dart';
+
+abstract class MovieRecommendationsUseCase {
+  Future<MovieRecommendations> getMovieRecommendations(
+    int movieId,
+    String apiKey,
+    String language,
+  );
+}

--- a/lib/features/movies/domain/usecases/details/movie_recommendations_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/details/movie_recommendations_use_case_impl.dart
@@ -1,0 +1,18 @@
+import '../../models/movie_recommendations.dart';
+import '../../repositories/movie_repository.dart';
+import 'movie_recommendations_use_case.dart';
+
+class MovieRecommendationsUseCaseImpl extends MovieRecommendationsUseCase {
+  MovieRecommendationsUseCaseImpl({required this.repository});
+
+  final MovieRepository repository;
+
+  @override
+  Future<MovieRecommendations> getMovieRecommendations(
+    int movieId,
+    String apiKey,
+    String language,
+  ) {
+    return repository.getMovieRecommendations(movieId, apiKey, language);
+  }
+}

--- a/lib/features/movies/domain/usecases/details/movie_reviews_use_case.dart
+++ b/lib/features/movies/domain/usecases/details/movie_reviews_use_case.dart
@@ -1,0 +1,9 @@
+import '../../models/movie_reviews.dart';
+
+abstract class MovieReviewsUseCase {
+  Future<MovieReviews> getMovieReviews(
+    int movieId,
+    String apiKey,
+    String language,
+  );
+}

--- a/lib/features/movies/domain/usecases/details/movie_reviews_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/details/movie_reviews_use_case_impl.dart
@@ -1,0 +1,18 @@
+import '../../models/movie_reviews.dart';
+import '../../repositories/movie_repository.dart';
+import 'movie_reviews_use_case.dart';
+
+class MovieReviewsUseCaseImpl extends MovieReviewsUseCase {
+  MovieReviewsUseCaseImpl({required this.repository});
+
+  final MovieRepository repository;
+
+  @override
+  Future<MovieReviews> getMovieReviews(
+    int movieId,
+    String apiKey,
+    String language,
+  ) {
+    return repository.getMovieReviews(movieId, apiKey, language);
+  }
+}

--- a/lib/features/movies/domain/usecases/details/movie_watch_providers_use_case.dart
+++ b/lib/features/movies/domain/usecases/details/movie_watch_providers_use_case.dart
@@ -1,0 +1,9 @@
+import '../../models/movie_watch_providers.dart';
+
+abstract class MovieWatchProvidersUseCase {
+  Future<MovieWatchProviders> getMovieWatchProviders(
+    int movieId,
+    String apiKey,
+    String region,
+  );
+}

--- a/lib/features/movies/domain/usecases/details/movie_watch_providers_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/details/movie_watch_providers_use_case_impl.dart
@@ -1,0 +1,18 @@
+import '../../models/movie_watch_providers.dart';
+import '../../repositories/movie_repository.dart';
+import 'movie_watch_providers_use_case.dart';
+
+class MovieWatchProvidersUseCaseImpl extends MovieWatchProvidersUseCase {
+  MovieWatchProvidersUseCaseImpl({required this.repository});
+
+  final MovieRepository repository;
+
+  @override
+  Future<MovieWatchProviders> getMovieWatchProviders(
+    int movieId,
+    String apiKey,
+    String region,
+  ) {
+    return repository.getMovieWatchProviders(movieId, apiKey, region);
+  }
+}

--- a/lib/features/movies/domain/usecases/usecases.dart
+++ b/lib/features/movies/domain/usecases/usecases.dart
@@ -10,5 +10,15 @@ export 'package:tmdb_flutter_app/features/movies/domain/usecases/trending/trendi
 export 'package:tmdb_flutter_app/features/movies/domain/usecases/trending/trending_movies_use_case_impl.dart';
 export 'package:tmdb_flutter_app/features/home/domain/usecases/discover_movies/discover_movies_use_case.dart';
 export 'package:tmdb_flutter_app/features/home/domain/usecases/discover_movies/discover_movies_use_case_impl.dart';
+export 'package:tmdb_flutter_app/features/movies/domain/usecases/details/movie_details_use_case.dart';
+export 'package:tmdb_flutter_app/features/movies/domain/usecases/details/movie_details_use_case_impl.dart';
+export 'package:tmdb_flutter_app/features/movies/domain/usecases/details/movie_credits_use_case.dart';
+export 'package:tmdb_flutter_app/features/movies/domain/usecases/details/movie_credits_use_case_impl.dart';
+export 'package:tmdb_flutter_app/features/movies/domain/usecases/details/movie_reviews_use_case.dart';
+export 'package:tmdb_flutter_app/features/movies/domain/usecases/details/movie_reviews_use_case_impl.dart';
+export 'package:tmdb_flutter_app/features/movies/domain/usecases/details/movie_recommendations_use_case.dart';
+export 'package:tmdb_flutter_app/features/movies/domain/usecases/details/movie_recommendations_use_case_impl.dart';
+export 'package:tmdb_flutter_app/features/movies/domain/usecases/details/movie_watch_providers_use_case.dart';
+export 'package:tmdb_flutter_app/features/movies/domain/usecases/details/movie_watch_providers_use_case_impl.dart';
 
 export 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dart';

--- a/lib/features/movies/presentation/bloc/movie_details/movie_details_bloc.dart
+++ b/lib/features/movies/presentation/bloc/movie_details/movie_details_bloc.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+import 'package:talker_flutter/talker_flutter.dart';
+
+import '../../../auth/domain/repositories/auth_repository.dart';
+import '../../../common/common.dart';
+import '../../domain/models/movie_credits.dart';
+import '../../domain/models/movie_detail.dart';
+import '../../domain/models/movie_recommendations.dart';
+import '../../domain/models/movie_reviews.dart';
+import '../../domain/models/movie_watch_providers.dart';
+import '../../domain/usecases/usecases.dart';
+
+part 'movie_details_event.dart';
+part 'movie_details_state.dart';
+
+class MovieDetailsBloc extends Bloc<MovieDetailsEvent, MovieDetailsState> {
+  MovieDetailsBloc({
+    required this.movieDetailsUseCase,
+    required this.movieCreditsUseCase,
+    required this.movieReviewsUseCase,
+    required this.movieRecommendationsUseCase,
+    required this.movieWatchProvidersUseCase,
+    required this.authRepository,
+  }) : super(MovieDetailsInitial()) {
+    on<LoadMovieDetails>(_onLoad);
+  }
+
+  final MovieDetailsUseCase movieDetailsUseCase;
+  final MovieCreditsUseCase movieCreditsUseCase;
+  final MovieReviewsUseCase movieReviewsUseCase;
+  final MovieRecommendationsUseCase movieRecommendationsUseCase;
+  final MovieWatchProvidersUseCase movieWatchProvidersUseCase;
+  final AuthRepository authRepository;
+
+  Future<void> _onLoad(
+    LoadMovieDetails event,
+    Emitter<MovieDetailsState> emit,
+  ) async {
+    emit(MovieDetailsLoading());
+    try {
+      final apiKey = await authRepository.requireApiKey();
+      final language = event.language ?? 'en-US';
+      final region = event.region ?? 'US';
+
+      final detail = await movieDetailsUseCase.getMovieDetails(
+        event.movieId,
+        apiKey,
+        language,
+      );
+      final credits = await movieCreditsUseCase.getMovieCredits(
+        event.movieId,
+        apiKey,
+        language,
+      );
+      final reviews = await movieReviewsUseCase.getMovieReviews(
+        event.movieId,
+        apiKey,
+        language,
+      );
+      final recommendations =
+          await movieRecommendationsUseCase.getMovieRecommendations(
+        event.movieId,
+        apiKey,
+        language,
+      );
+      final watchProviders =
+          await movieWatchProvidersUseCase.getMovieWatchProviders(
+        event.movieId,
+        apiKey,
+        region,
+      );
+
+      emit(
+        MovieDetailsLoaded(
+          detail: detail,
+          credits: credits,
+          reviews: reviews,
+          recommendations: recommendations,
+          watchProviders: watchProviders,
+        ),
+      );
+    } catch (e) {
+      emit(MovieDetailsFailure(exception: e));
+    }
+  }
+
+  @override
+  void onError(Object error, StackTrace stackTrace) {
+    super.onError(error, stackTrace);
+    GetIt.I<Talker>().handle(error, stackTrace);
+  }
+}

--- a/lib/features/movies/presentation/bloc/movie_details/movie_details_event.dart
+++ b/lib/features/movies/presentation/bloc/movie_details/movie_details_event.dart
@@ -1,0 +1,23 @@
+part of 'movie_details_bloc.dart';
+
+abstract class MovieDetailsEvent extends UiEvent {
+  MovieDetailsEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadMovieDetails extends MovieDetailsEvent {
+  LoadMovieDetails({
+    required this.movieId,
+    this.language,
+    this.region,
+  });
+
+  final int movieId;
+  final String? language;
+  final String? region;
+
+  @override
+  List<Object?> get props => [movieId, language, region];
+}

--- a/lib/features/movies/presentation/bloc/movie_details/movie_details_state.dart
+++ b/lib/features/movies/presentation/bloc/movie_details/movie_details_state.dart
@@ -1,0 +1,50 @@
+part of 'movie_details_bloc.dart';
+
+abstract class MovieDetailsState extends UiState {
+  MovieDetailsState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class MovieDetailsInitial extends MovieDetailsState {
+  MovieDetailsInitial();
+}
+
+class MovieDetailsLoading extends MovieDetailsState {
+  MovieDetailsLoading();
+}
+
+class MovieDetailsLoaded extends MovieDetailsState {
+  MovieDetailsLoaded({
+    required this.detail,
+    required this.credits,
+    required this.reviews,
+    required this.recommendations,
+    required this.watchProviders,
+  });
+
+  final MovieDetail detail;
+  final MovieCredits credits;
+  final MovieReviews reviews;
+  final MovieRecommendations recommendations;
+  final MovieWatchProviders watchProviders;
+
+  @override
+  List<Object?> get props => [
+        detail,
+        credits,
+        reviews,
+        recommendations,
+        watchProviders,
+      ];
+}
+
+class MovieDetailsFailure extends MovieDetailsState {
+  MovieDetailsFailure({required this.exception});
+
+  final Object exception;
+
+  @override
+  List<Object?> get props => [exception];
+}

--- a/lib/features/movies/presentation/screens/movie_details_screen.dart
+++ b/lib/features/movies/presentation/screens/movie_details_screen.dart
@@ -1,184 +1,679 @@
+import 'dart:async';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
 
+import '../../../auth/domain/repositories/auth_repository.dart';
 import '../../domain/models/movie.dart';
+import '../../domain/models/movie_credit.dart';
+import '../../domain/models/movie_credits.dart';
+import '../../domain/models/movie_detail.dart';
+import '../../domain/models/movie_recommendation.dart';
+import '../../domain/models/movie_recommendations.dart';
+import '../../domain/models/movie_reviews.dart';
+import '../../domain/models/movie_watch_providers.dart';
+import '../../domain/models/watch_provider.dart';
+import '../../domain/usecases/usecases.dart';
+import '../bloc/movie_details/movie_details_bloc.dart';
 
 @RoutePage()
 class MovieDetailsScreen extends StatelessWidget {
-  const MovieDetailsScreen({super.key, required this.movie});
+  const MovieDetailsScreen({
+    super.key,
+    required this.movie,
+    this.blocOverride,
+  });
 
   final Movie movie;
+  final MovieDetailsBloc? blocOverride;
+
+  @override
+  Widget build(BuildContext context) {
+    final movieId = movie.id;
+    if (movieId == null) {
+      return Scaffold(
+        appBar: AppBar(title: Text(movie.title ?? 'Movie Details')),
+        body: const Center(
+          child: Text('Movie details are unavailable for this title.'),
+        ),
+      );
+    }
+
+    final body = _MovieDetailsView(movie: movie, movieId: movieId);
+
+    if (blocOverride != null) {
+      return BlocProvider<MovieDetailsBloc>.value(
+        value: blocOverride!,
+        child: body,
+      );
+    }
+
+    return BlocProvider<MovieDetailsBloc>(
+      create: (_) {
+        final bloc = MovieDetailsBloc(
+          movieDetailsUseCase: GetIt.I<MovieDetailsUseCase>(),
+          movieCreditsUseCase: GetIt.I<MovieCreditsUseCase>(),
+          movieReviewsUseCase: GetIt.I<MovieReviewsUseCase>(),
+          movieRecommendationsUseCase: GetIt.I<MovieRecommendationsUseCase>(),
+          movieWatchProvidersUseCase: GetIt.I<MovieWatchProvidersUseCase>(),
+          authRepository: GetIt.I<AuthRepository>(),
+        );
+        scheduleMicrotask(
+          () => bloc.add(LoadMovieDetails(movieId: movieId)),
+        );
+        return bloc;
+      },
+      child: body,
+    );
+  }
+}
+
+class _MovieDetailsView extends StatelessWidget {
+  const _MovieDetailsView({
+    required this.movie,
+    required this.movieId,
+  });
+
+  final Movie movie;
+  final int movieId;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<MovieDetailsBloc, MovieDetailsState>(
+      builder: (context, state) {
+        if (state is MovieDetailsFailure) {
+          return Scaffold(
+            appBar: AppBar(title: Text(movie.title ?? 'Movie #$movieId')),
+            body: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'We weren\'t able to load the movie details.\n${state.exception}',
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    FilledButton(
+                      onPressed: () => context
+                          .read<MovieDetailsBloc>()
+                          .add(LoadMovieDetails(movieId: movieId)),
+                      child: const Text('Try again'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        }
+
+        if (state is MovieDetailsLoaded) {
+          return _MovieDetailsContent(
+            movie: movie,
+            detail: state.detail,
+            credits: state.credits,
+            reviews: state.reviews,
+            recommendations: state.recommendations,
+            watchProviders: state.watchProviders,
+          );
+        }
+
+        return Scaffold(
+          appBar: AppBar(title: Text(movie.title ?? 'Movie #$movieId')),
+          body: const Center(child: CircularProgressIndicator()),
+        );
+      },
+    );
+  }
+}
+
+class _MovieDetailsContent extends StatelessWidget {
+  const _MovieDetailsContent({
+    required this.movie,
+    required this.detail,
+    required this.credits,
+    required this.reviews,
+    required this.recommendations,
+    required this.watchProviders,
+  });
+
+  final Movie movie;
+  final MovieDetail detail;
+  final MovieCredits credits;
+  final MovieReviews reviews;
+  final MovieRecommendations recommendations;
+  final MovieWatchProviders watchProviders;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final textTheme = theme.textTheme;
-    final backdropUrl = movie.backdropPath != null
-        ? 'https://image.tmdb.org/t/p/w780/${movie.backdropPath}'
-        : null;
-    final posterUrl = movie.posterPath != null
-        ? 'https://image.tmdb.org/t/p/w342/${movie.posterPath}'
-        : null;
-    final voteAverage = movie.voteAverage != null
-        ? movie.voteAverage!.toStringAsFixed(1)
-        : '–';
-    final voteCount = movie.voteCount?.toString() ?? '–';
-    final releaseDate = movie.releaseDate ?? 'Unknown';
-    final language = movie.originalLanguage?.toUpperCase() ?? 'N/A';
-    final popularity = movie.popularity != null
-        ? movie.popularity!.toStringAsFixed(0)
-        : '–';
+    final backgroundUrl = _imageUrl(detail.backdropPath ?? movie.backdropPath, 'w780');
 
-    return Scaffold(
-      body: CustomScrollView(
-        slivers: [
-          SliverAppBar(
-            backgroundColor: theme.colorScheme.surface,
-            expandedHeight: 320,
-            pinned: true,
-            flexibleSpace: FlexibleSpaceBar(
-              title: Text(movie.title ?? 'Movie Details'),
-              background: Stack(
-                fit: StackFit.expand,
-                children: [
-                  if (backdropUrl != null)
-                    Image.network(backdropUrl, fit: BoxFit.cover)
-                  else
-                    Container(color: Colors.black12),
-                  const DecoratedBox(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [Colors.transparent, Colors.black54],
+    return DefaultTabController(
+      length: 5,
+      child: Scaffold(
+        body: NestedScrollView(
+          headerSliverBuilder: (context, innerBoxIsScrolled) => [
+            SliverAppBar(
+              backgroundColor: theme.colorScheme.surface,
+              expandedHeight: 300,
+              pinned: true,
+              flexibleSpace: FlexibleSpaceBar(
+                title: Text(detail.title ?? movie.title ?? 'Movie Details'),
+                background: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    if (backgroundUrl != null)
+                      Image.network(backgroundUrl, fit: BoxFit.cover)
+                    else
+                      Container(color: theme.colorScheme.surfaceVariant),
+                    const DecoratedBox(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [Colors.transparent, Colors.black54],
+                        ),
                       ),
                     ),
+                  ],
+                ),
+              ),
+              bottom: PreferredSize(
+                preferredSize: const Size.fromHeight(48),
+                child: Container(
+                  color: theme.colorScheme.surface,
+                  child: const TabBar(
+                    isScrollable: true,
+                    tabs: [
+                      Tab(text: 'Overview'),
+                      Tab(text: 'Cast & Crew'),
+                      Tab(text: 'Reviews'),
+                      Tab(text: 'Where to Watch'),
+                      Tab(text: 'Recommendations'),
+                    ],
                   ),
-                ],
+                ),
               ),
             ),
+          ],
+          body: TabBarView(
+            children: [
+              _OverviewTab(detail: detail, movie: movie, credits: credits),
+              _CastCrewTab(credits: credits),
+              _ReviewsTab(reviews: reviews),
+              _WatchProvidersTab(providers: watchProviders),
+              _RecommendationsTab(recommendations: recommendations),
+            ],
           ),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
+        ),
+      ),
+    );
+  }
+}
+
+class _OverviewTab extends StatelessWidget {
+  const _OverviewTab({
+    required this.detail,
+    required this.movie,
+    required this.credits,
+  });
+
+  final MovieDetail detail;
+  final Movie movie;
+  final MovieCredits credits;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final runtime = _formatRuntime(detail.runtime);
+    final genres = detail.genres
+        .map((g) => g.name)
+        .whereType<String>()
+        .where((name) => name.isNotEmpty)
+        .toList();
+    final posterUrl = _imageUrl(detail.posterPath ?? movie.posterPath, 'w342');
+    final crewHighlights = _crewHighlights(credits);
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: posterUrl != null
+                  ? Image.network(
+                      posterUrl,
+                      width: 140,
+                      height: 210,
+                      fit: BoxFit.cover,
+                    )
+                  : Container(
+                      width: 140,
+                      height: 210,
+                      color: theme.colorScheme.surfaceVariant,
+                      child: const Icon(Icons.movie, size: 48),
+                    ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (posterUrl != null)
-                        ClipRRect(
-                          borderRadius: BorderRadius.circular(12),
-                          child: Image.network(
-                            posterUrl,
-                            width: 120,
-                            height: 180,
-                            fit: BoxFit.cover,
-                          ),
-                        )
-                      else
-                        Container(
-                          width: 120,
-                          height: 180,
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(12),
-                            color: theme.colorScheme.surfaceContainerHighest,
-                          ),
-                          child: const Icon(Icons.movie, size: 48),
-                        ),
-                      const SizedBox(width: 16),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              movie.title ?? 'Untitled',
-                              style: textTheme.headlineSmall?.copyWith(
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            const SizedBox(height: 8),
-                            Wrap(
-                              spacing: 8,
-                              runSpacing: 8,
-                              children: [
-                                _InfoChip(
-                                  icon: Icons.calendar_today,
-                                  label: releaseDate,
-                                ),
-                                _InfoChip(
-                                  icon: Icons.language,
-                                  label: language,
-                                ),
-                                _InfoChip(
-                                  icon: Icons.people,
-                                  label: 'Votes $voteCount',
-                                ),
-                                _InfoChip(
-                                  icon: Icons.trending_up,
-                                  label: 'Popularity $popularity',
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
-                  Row(
-                    children: [
-                      Icon(Icons.star, color: theme.colorScheme.secondary),
-                      const SizedBox(width: 8),
-                      Text(
-                        voteAverage,
-                        style: textTheme.titleLarge?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      Text('User Score', style: textTheme.titleMedium),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
                   Text(
-                    'Overview',
-                    style: textTheme.titleLarge?.copyWith(
+                    detail.title ?? movie.title ?? 'Untitled',
+                    style: theme.textTheme.headlineSmall?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  const SizedBox(height: 8),
-                  Text(
-                    movie.overview?.isNotEmpty == true
-                        ? movie.overview!
-                        : 'No overview available for this movie yet.',
-                    style: textTheme.bodyLarge,
-                  ),
-                  const SizedBox(height: 24),
-                  Text(
-                    'Additional Details',
-                    style: textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.bold,
+                  if ((detail.tagline ?? '').isNotEmpty) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      detail.tagline!,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: theme.colorScheme.secondary,
+                        fontStyle: FontStyle.italic,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  _InfoRow(
-                    title: 'Original Title',
-                    value: movie.originalTitle ?? '–',
-                  ),
-                  _InfoRow(title: 'Release Date', value: releaseDate),
-                  _InfoRow(title: 'Original Language', value: language),
-                  _InfoRow(
-                    title: 'Adult',
-                    value: movie.adult == true ? 'Yes' : 'No',
+                  ],
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      if (detail.releaseDate != null && detail.releaseDate!.isNotEmpty)
+                        _InfoChip(icon: Icons.calendar_today, label: detail.releaseDate!),
+                      if (runtime != null)
+                        _InfoChip(icon: Icons.access_time, label: runtime),
+                      if (genres.isNotEmpty)
+                        _InfoChip(icon: Icons.local_offer, label: genres.join(' • ')),
+                      if (detail.voteAverage != null)
+                        _InfoChip(
+                          icon: Icons.star_rate,
+                          label:
+                              '${detail.voteAverage!.toStringAsFixed(1)} (${detail.voteCount ?? 0} votes)',
+                        ),
+                      if (detail.originalLanguage != null)
+                        _InfoChip(
+                          icon: Icons.language,
+                          label: detail.originalLanguage!.toUpperCase(),
+                        ),
+                    ],
                   ),
                 ],
               ),
             ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        Text(
+          'Overview',
+          style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          (detail.overview ?? movie.overview ?? '').isNotEmpty
+              ? (detail.overview ?? movie.overview!)
+              : 'No overview available for this movie yet.',
+          style: theme.textTheme.bodyLarge,
+        ),
+        const SizedBox(height: 24),
+        if (crewHighlights.isNotEmpty) ...[
+          Text(
+            'Featured Crew',
+            style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
           ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: crewHighlights
+                .map(
+                  (member) => SizedBox(
+                    width: 160,
+                    child: _CrewCard(member: member),
+                  ),
+                )
+                .toList(),
+          ),
+          const SizedBox(height: 24),
+        ],
+        Text(
+          'Facts',
+          style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        _InfoRow(title: 'Original Title', value: detail.originalTitle ?? movie.originalTitle ?? '—'),
+        _InfoRow(title: 'Status', value: detail.status ?? '—'),
+        _InfoRow(title: 'Popularity', value: detail.popularity?.toStringAsFixed(0) ?? '—'),
+        if (detail.homepage != null && detail.homepage!.isNotEmpty)
+          _InfoRow(title: 'Homepage', value: detail.homepage!),
+      ],
+    );
+  }
+}
+
+class _CastCrewTab extends StatelessWidget {
+  const _CastCrewTab({required this.credits});
+
+  final MovieCredits credits;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cast = [...credits.cast]..sort((a, b) => (a.order ?? 0).compareTo(b.order ?? 0));
+    final crew = [...credits.crew];
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text(
+          'Top Cast',
+          style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+        if (cast.isEmpty)
+          const Text('No cast information available.')
+        else
+          ...cast.take(12).map((member) => _PersonTile(member: member)),
+        const SizedBox(height: 24),
+        Text(
+          'Key Crew',
+          style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+        if (crew.isEmpty)
+          const Text('No crew information available.')
+        else
+          ...crew
+              .where((member) => (member.job ?? '').isNotEmpty)
+              .take(12)
+              .map((member) => _PersonTile(member: member)),
+      ],
+    );
+  }
+}
+
+class _ReviewsTab extends StatelessWidget {
+  const _ReviewsTab({required this.reviews});
+
+  final MovieReviews reviews;
+
+  @override
+  Widget build(BuildContext context) {
+    if (reviews.results.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text('No reviews have been written for this movie yet.'),
+        ),
+      );
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemBuilder: (context, index) {
+        final review = reviews.results[index];
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  review.author ?? 'Anonymous',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  review.content ?? 'No review text provided.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                if (review.createdAt != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    'Written on ${review.createdAt!.toLocal()}'.split('.').first,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(color: Theme.of(context).hintColor),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemCount: reviews.results.length,
+    );
+  }
+}
+
+class _WatchProvidersTab extends StatelessWidget {
+  const _WatchProvidersTab({required this.providers});
+
+  final MovieWatchProviders providers;
+
+  @override
+  Widget build(BuildContext context) {
+    final sections = <Widget>[];
+
+    void addSection(String title, List<WatchProvider> items) {
+      if (items.isEmpty) return;
+      sections.add(Text(
+        title,
+        style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+      ));
+      sections.add(const SizedBox(height: 12));
+      sections.addAll(
+        items.map((item) => _ProviderTile(provider: item)),
+      );
+      sections.add(const SizedBox(height: 24));
+    }
+
+    addSection('Streaming', providers.flatrate);
+    addSection('Rent', providers.rent);
+    addSection('Buy', providers.buy);
+    addSection('Ad-supported', providers.ads);
+    addSection('Free', providers.free);
+
+    if (sections.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text('We couldn\'t find any watch providers for this region.'),
+        ),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        if (providers.link != null && providers.link!.isNotEmpty) ...[
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.open_in_new),
+              title: const Text('View on TMDB'),
+              subtitle: SelectableText(providers.link!),
+            ),
+          ),
+          const SizedBox(height: 24),
+        ],
+        ...sections,
+      ],
+    );
+  }
+}
+
+class _RecommendationsTab extends StatelessWidget {
+  const _RecommendationsTab({required this.recommendations});
+
+  final MovieRecommendations recommendations;
+
+  @override
+  Widget build(BuildContext context) {
+    if (recommendations.results.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text('No recommendations found yet.'),
+        ),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Wrap(
+          spacing: 16,
+          runSpacing: 16,
+          children: recommendations.results
+              .take(12)
+              .map((rec) => _RecommendationCard(recommendation: rec))
+              .toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _RecommendationCard extends StatelessWidget {
+  const _RecommendationCard({required this.recommendation});
+
+  final MovieRecommendation recommendation;
+
+  @override
+  Widget build(BuildContext context) {
+    final posterUrl = _imageUrl(recommendation.posterPath, 'w185');
+    return SizedBox(
+      width: 120,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: posterUrl != null
+                ? Image.network(
+                    posterUrl,
+                    width: 120,
+                    height: 180,
+                    fit: BoxFit.cover,
+                  )
+                : Container(
+                    width: 120,
+                    height: 180,
+                    color: Theme.of(context).colorScheme.surfaceVariant,
+                    child: const Icon(Icons.movie),
+                  ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            recommendation.title ?? 'Untitled',
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          if (recommendation.voteAverage != null)
+            Text(
+              recommendation.voteAverage!.toStringAsFixed(1),
+              style: Theme.of(context)
+                  .textTheme
+                  .labelMedium
+                  ?.copyWith(color: Theme.of(context).colorScheme.secondary),
+            ),
         ],
       ),
+    );
+  }
+}
+
+class _CrewCard extends StatelessWidget {
+  const _CrewCard({required this.member});
+
+  final MovieCredit member;
+
+  @override
+  Widget build(BuildContext context) {
+    final avatarUrl = _imageUrl(member.profilePath, 'w185');
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          children: [
+            CircleAvatar(
+              radius: 32,
+              backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
+              backgroundImage: avatarUrl != null ? NetworkImage(avatarUrl) : null,
+              child: avatarUrl == null ? const Icon(Icons.person) : null,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              member.name ?? 'Unknown',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              member.job ?? 'Crew',
+              textAlign: TextAlign.center,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: Theme.of(context).hintColor),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PersonTile extends StatelessWidget {
+  const _PersonTile({required this.member});
+
+  final MovieCredit member;
+
+  @override
+  Widget build(BuildContext context) {
+    final avatarUrl = _imageUrl(member.profilePath, 'w185');
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: CircleAvatar(
+        radius: 24,
+        backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
+        backgroundImage: avatarUrl != null ? NetworkImage(avatarUrl) : null,
+        child: avatarUrl == null ? const Icon(Icons.person) : null,
+      ),
+      title: Text(member.name ?? 'Unknown'),
+      subtitle: Text(member.role ?? '—'),
+    );
+  }
+}
+
+class _ProviderTile extends StatelessWidget {
+  const _ProviderTile({required this.provider});
+
+  final WatchProvider provider;
+
+  @override
+  Widget build(BuildContext context) {
+    final logoUrl = _imageUrl(provider.logoPath, 'w92');
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: CircleAvatar(
+        radius: 24,
+        backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
+        backgroundImage: logoUrl != null ? NetworkImage(logoUrl) : null,
+        child: logoUrl == null ? const Icon(Icons.live_tv) : null,
+      ),
+      title: Text(provider.providerName ?? 'Unknown'),
+      subtitle: Text('Provider ID: ${provider.providerId ?? '—'}'),
     );
   }
 }
@@ -226,9 +721,58 @@ class _InfoRow extends StatelessWidget {
             child: Text(title, style: textTheme.titleMedium),
           ),
           const SizedBox(width: 8),
-          Expanded(child: Text(value, style: textTheme.bodyLarge)),
+          Expanded(
+            child: Text(
+              value,
+              style: textTheme.bodyLarge,
+            ),
+          ),
         ],
       ),
     );
   }
+}
+
+String? _imageUrl(String? path, String size) {
+  if (path == null || path.isEmpty) {
+    return null;
+  }
+  return 'https://image.tmdb.org/t/p/$size$path';
+}
+
+String? _formatRuntime(int? runtime) {
+  if (runtime == null || runtime <= 0) {
+    return null;
+  }
+  final hours = runtime ~/ 60;
+  final minutes = runtime % 60;
+  if (hours == 0) {
+    return '${minutes}m';
+  }
+  if (minutes == 0) {
+    return '${hours}h';
+  }
+  return '${hours}h ${minutes}m';
+}
+
+List<MovieCredit> _crewHighlights(MovieCredits credits) {
+  final highlights = <MovieCredit>[];
+  final seenJobs = <String>{};
+  for (final member in credits.crew) {
+    final job = member.job;
+    if (job == null || job.isEmpty) continue;
+    final normalized = job.toLowerCase();
+    if (seenJobs.contains(normalized)) continue;
+    if (normalized.contains('director') ||
+        normalized.contains('writer') ||
+        normalized.contains('screenplay') ||
+        normalized.contains('producer')) {
+      highlights.add(member);
+      seenJobs.add(normalized);
+    }
+    if (highlights.length >= 6) {
+      break;
+    }
+  }
+  return highlights;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,6 +122,36 @@ Future<void> main() async {
           TopRatedMoviesUseCaseImpl(repository: di.get<MovieRepository>()),
     );
 
+    di.registerLazySingleton<MovieDetailsUseCase>(
+      () => MovieDetailsUseCaseImpl(
+        repository: di.get<MovieRepository>(),
+      ),
+    );
+
+    di.registerLazySingleton<MovieCreditsUseCase>(
+      () => MovieCreditsUseCaseImpl(
+        repository: di.get<MovieRepository>(),
+      ),
+    );
+
+    di.registerLazySingleton<MovieReviewsUseCase>(
+      () => MovieReviewsUseCaseImpl(
+        repository: di.get<MovieRepository>(),
+      ),
+    );
+
+    di.registerLazySingleton<MovieRecommendationsUseCase>(
+      () => MovieRecommendationsUseCaseImpl(
+        repository: di.get<MovieRepository>(),
+      ),
+    );
+
+    di.registerLazySingleton<MovieWatchProvidersUseCase>(
+      () => MovieWatchProvidersUseCaseImpl(
+        repository: di.get<MovieRepository>(),
+      ),
+    );
+
     di.registerLazySingleton<DiscoverContentUseCase>(
       () =>
           DiscoverContentUseCaseImpl(repository: di.get<HomeRepository>()),


### PR DESCRIPTION
## Summary
- extend the movie repository and add new domain models to fetch details, credits, reviews, recommendations, and watch providers from TMDB
- wire up dedicated use cases plus a MovieDetailsBloc to orchestrate the detail data loading
- redesign the MovieDetailsScreen to consume the bloc and present the overview, cast, reviews, providers, and recommendations in tabs

## Testing
- not run (flutter toolchain is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e196515b7c8323892c745578a981a9