### PR TITLE
Refactor API authorization to rely on interceptors

### DIFF
--- a/lib/features/actors/data/repositories/actors_repository_impl.dart
+++ b/lib/features/actors/data/repositories/actors_repository_impl.dart
@@ -25,12 +25,10 @@ class ActorsRepositoryImpl extends ActorsRepository {
   @override
   Future<ActorsListEntity> getPopularActors(
     int page,
-    String apiKey,
     String language,
   ) async {
     final String endpoint = '/person/popular';
     final params = <String, dynamic>{
-      'api_key': apiKey,
       'language': language,
       'page': page, // caller controls pagination
     };
@@ -77,7 +75,6 @@ class ActorsRepositoryImpl extends ActorsRepository {
   @override
   Future<ActorDetails> getActorDetails(
     int actorId,
-    String apiKey,
     String language,
   ) async {
     final cached = _actorDetailsCache[actorId];
@@ -90,7 +87,6 @@ class ActorsRepositoryImpl extends ActorsRepository {
 
     final String endpoint = '/person/$actorId';
     final params = <String, dynamic>{
-      'api_key': apiKey,
       'language': language,
     };
 

--- a/lib/features/actors/domain/repositories/actors_repository.dart
+++ b/lib/features/actors/domain/repositories/actors_repository.dart
@@ -4,13 +4,11 @@ import '../models/actors_list_entity.dart';
 abstract class ActorsRepository {
   Future<ActorsListEntity> getPopularActors(
     int page,
-    String apiKey,
     String language,
   );
 
   Future<ActorDetails> getActorDetails(
     int actorId,
-    String apiKey,
     String language,
   );
 }

--- a/lib/features/actors/domain/usecases/details/actor_details_use_case.dart
+++ b/lib/features/actors/domain/usecases/details/actor_details_use_case.dart
@@ -3,7 +3,6 @@ import '../../models/actor_details.dart';
 abstract class ActorDetailsUseCase {
   Future<ActorDetails> getActorDetails(
     int actorId,
-    String apiKey,
     String language,
   );
 }

--- a/lib/features/actors/domain/usecases/details/actor_details_use_case_impl.dart
+++ b/lib/features/actors/domain/usecases/details/actor_details_use_case_impl.dart
@@ -10,9 +10,8 @@ class ActorDetailsUseCaseImpl extends ActorDetailsUseCase {
   @override
   Future<ActorDetails> getActorDetails(
     int actorId,
-    String apiKey,
     String language,
   ) {
-    return repository.getActorDetails(actorId, apiKey, language);
+    return repository.getActorDetails(actorId, language);
   }
 }

--- a/lib/features/actors/domain/usecases/popular/popular_actors_use_case.dart
+++ b/lib/features/actors/domain/usecases/popular/popular_actors_use_case.dart
@@ -3,7 +3,6 @@ import 'package:tmdb_flutter_app/features/actors/domain/models/actors_list_entit
 abstract class PopularActorsUseCase {
   Future<ActorsListEntity> getPopularActors(
     int page,
-    String apiKey,
     String language,
   );
 }

--- a/lib/features/actors/domain/usecases/popular/popular_actors_use_case_impl.dart
+++ b/lib/features/actors/domain/usecases/popular/popular_actors_use_case_impl.dart
@@ -10,9 +10,8 @@ class PopularActorsUseCaseImpl extends PopularActorsUseCase {
   @override
   Future<ActorsListEntity> getPopularActors(
     int page,
-    String apiKey,
     String language,
   ) async {
-    return repository.getPopularActors(page, apiKey, language);
+    return repository.getPopularActors(page, language);
   }
 }

--- a/lib/features/actors/presentation/bloc/actor_details_bloc.dart
+++ b/lib/features/actors/presentation/bloc/actor_details_bloc.dart
@@ -7,19 +7,17 @@ import 'package:talker_flutter/talker_flutter.dart';
 import '../../../common/common.dart';
 import '../../domain/models/actor_details.dart';
 import '../../domain/usecases/usecases.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'actor_details_event.dart';
 part 'actor_details_state.dart';
 
 class ActorDetailsBloc extends Bloc<ActorDetailsEvent, ActorDetailsState> {
-  ActorDetailsBloc(this.actorDetailsUseCase, this.authRepository)
+  ActorDetailsBloc(this.actorDetailsUseCase)
       : super(ActorDetailsInitial()) {
     on<LoadActorDetails>(_onLoad);
   }
 
   final ActorDetailsUseCase actorDetailsUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _onLoad(
     LoadActorDetails event,
@@ -27,10 +25,8 @@ class ActorDetailsBloc extends Bloc<ActorDetailsEvent, ActorDetailsState> {
   ) async {
     emit(ActorDetailsLoading());
     try {
-      final apiKey = await authRepository.requireApiKey();
       final details = await actorDetailsUseCase.getActorDetails(
         event.actorId,
-        apiKey,
         event.language ?? 'en-US',
       );
       emit(ActorDetailsLoaded(actorDetails: details));

--- a/lib/features/actors/presentation/bloc/popular_actors_bloc.dart
+++ b/lib/features/actors/presentation/bloc/popular_actors_bloc.dart
@@ -6,20 +6,18 @@ import 'package:talker_flutter/talker_flutter.dart';
 import '../../../common/common.dart';
 import '../../domain/models/actors_list_result.dart';
 import 'package:tmdb_flutter_app/features/actors/domain/usecases/usecases.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'popular_actors_event.dart';
 
 part 'popular_actors_state.dart';
 
 class PopularActorsBloc extends Bloc<UiEvent, UiState> {
-  PopularActorsBloc(this.popularActorsUseCase, this.authRepository)
+  PopularActorsBloc(this.popularActorsUseCase)
       : super(PopularActorsInitial()) {
     on<LoadPopularActors>(_load);
   }
 
   final PopularActorsUseCase popularActorsUseCase;
-  final AuthRepository authRepository;
 
   // local pagination accumulator
   final List<ActorsListResults> _buffer = [];
@@ -50,10 +48,8 @@ class PopularActorsBloc extends Bloc<UiEvent, UiState> {
         return;
       }
 
-      final apiKey = await authRepository.requireApiKey();
       final result = await popularActorsUseCase.getPopularActors(
         _nextPage,
-        apiKey,
         'us-US',
       );
 

--- a/lib/features/actors/presentation/screens/actor_details_screen.dart
+++ b/lib/features/actors/presentation/screens/actor_details_screen.dart
@@ -7,7 +7,6 @@ import 'package:get_it/get_it.dart';
 
 import '../../domain/usecases/usecases.dart';
 import '../bloc/actor_details_bloc.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 @RoutePage()
 class ActorDetailsScreen extends StatelessWidget {
@@ -37,7 +36,6 @@ class ActorDetailsScreen extends StatelessWidget {
       create: (_) {
         final bloc = ActorDetailsBloc(
           GetIt.I<ActorDetailsUseCase>(),
-          GetIt.I<AuthRepository>(),
         );
         scheduleMicrotask(
           () => bloc.add(LoadActorDetails(actorId: actorId)),

--- a/lib/features/actors/presentation/screens/actors_screen.dart
+++ b/lib/features/actors/presentation/screens/actors_screen.dart
@@ -7,7 +7,6 @@ import '../../../common/common.dart';
 import '../../domain/usecases/popular/popular_actors_use_case.dart';
 import '../bloc/popular_actors_bloc.dart';
 import '../widgets/actor_card.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 @RoutePage()
 class ActorsScreen extends StatefulWidget {
@@ -24,7 +23,6 @@ class _ActorsScreenState extends State<ActorsScreen> {
       create: (_) =>
           PopularActorsBloc(
             GetIt.I<PopularActorsUseCase>(),
-            GetIt.I<AuthRepository>(),
           )..add(LoadPopularActors()),
       child: BlocBuilder<PopularActorsBloc, UiState>(
         builder: (context, state) {

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -13,7 +13,7 @@ class AuthRemoteDataSource {
     try {
       final response = await _dio.get(
         '/configuration',
-        queryParameters: {'api_key': apiKey},
+        options: _withAuthorization(apiKey),
       );
       return response.statusCode == 200;
     } on DioException catch (error) {
@@ -27,7 +27,7 @@ class AuthRemoteDataSource {
   Future<RequestTokenResponse> createRequestToken(String apiKey) async {
     final response = await _dio.get(
       '/authentication/token/new',
-      queryParameters: {'api_key': apiKey},
+      options: _withAuthorization(apiKey),
     );
     return RequestTokenResponse.fromJson(_mapResponse(response.data));
   }
@@ -40,12 +40,12 @@ class AuthRemoteDataSource {
   }) async {
     final response = await _dio.post(
       '/authentication/token/validate_with_login',
-      queryParameters: {'api_key': apiKey},
       data: {
         'username': username,
         'password': password,
         'request_token': requestToken,
       },
+      options: _withAuthorization(apiKey),
     );
     return RequestTokenResponse.fromJson(_mapResponse(response.data));
   }
@@ -56,8 +56,8 @@ class AuthRemoteDataSource {
   }) async {
     final response = await _dio.post(
       '/authentication/session/new',
-      queryParameters: {'api_key': apiKey},
       data: {'request_token': requestToken},
+      options: _withAuthorization(apiKey),
     );
     return SessionResponse.fromJson(_mapResponse(response.data));
   }
@@ -69,11 +69,19 @@ class AuthRemoteDataSource {
     final response = await _dio.get(
       '/account',
       queryParameters: {
-        'api_key': apiKey,
         'session_id': sessionId,
       },
+      options: _withAuthorization(apiKey),
     );
     return AccountResponse.fromJson(_mapResponse(response.data));
+  }
+
+  Options _withAuthorization(String apiKey) {
+    return Options(
+      headers: {
+        'Authorization': 'Bearer $apiKey',
+      },
+    );
   }
 
   Map<String, dynamic> _mapResponse(dynamic data) {

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -130,12 +130,4 @@ class AuthRepositoryImpl implements AuthRepository {
     return account.id;
   }
 
-  @override
-  Future<String> requireApiKey() async {
-    final apiKey = await getApiKey();
-    if (apiKey == null || apiKey.isEmpty) {
-      throw AuthException('TMDB API key has not been configured.');
-    }
-    return apiKey;
-  }
 }

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -25,6 +25,4 @@ abstract class AuthRepository {
     required String apiKey,
     required String sessionId,
   });
-
-  Future<String> requireApiKey();
 }

--- a/lib/features/auth/presentation/cubit/auth_state.dart
+++ b/lib/features/auth/presentation/cubit/auth_state.dart
@@ -12,13 +12,13 @@ enum AuthStatus {
 class AuthState extends Equatable {
   const AuthState({
     this.status = AuthStatus.initial,
-    this.apiKey,
+    this.hasApiKey = false,
     this.session,
     this.errorMessage,
   });
 
   final AuthStatus status;
-  final String? apiKey;
+  final bool hasApiKey;
   final AuthSession? session;
   final String? errorMessage;
 
@@ -27,7 +27,7 @@ class AuthState extends Equatable {
 
   AuthState copyWith({
     AuthStatus? status,
-    String? apiKey,
+    bool? hasApiKey,
     AuthSession? session,
     String? errorMessage,
     bool clearErrorMessage = false,
@@ -35,12 +35,12 @@ class AuthState extends Equatable {
   }) {
     return AuthState(
       status: status ?? this.status,
-      apiKey: apiKey ?? this.apiKey,
+      hasApiKey: hasApiKey ?? this.hasApiKey,
       session: clearSession ? null : (session ?? this.session),
       errorMessage: clearErrorMessage ? null : (errorMessage ?? this.errorMessage),
     );
   }
 
   @override
-  List<Object?> get props => [status, apiKey, session, errorMessage];
+  List<Object?> get props => [status, hasApiKey, session, errorMessage];
 }

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -36,7 +36,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
     return BlocListener<AuthCubit, AuthState>(
       listenWhen: (previous, current) => previous.status != current.status,
       listener: (context, state) {
-        if (state.status == AuthStatus.unauthenticated && state.apiKey != null) {
+        if (state.status == AuthStatus.unauthenticated && state.hasApiKey) {
           context.router.replaceAll([const SignInRoute()]);
         } else if (state.status == AuthStatus.failure && state.errorMessage != null) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/auth/presentation/screens/sign_in_screen.dart
+++ b/lib/features/auth/presentation/screens/sign_in_screen.dart
@@ -37,15 +37,6 @@ class _SignInScreenState extends State<SignInScreen> {
     }
   }
 
-  String _maskApiKey(String apiKey) {
-    if (apiKey.length <= 8) {
-      return apiKey;
-    }
-    final prefix = apiKey.substring(0, 4);
-    final suffix = apiKey.substring(apiKey.length - 4);
-    return '$prefix••••$suffix';
-  }
-
   @override
   Widget build(BuildContext context) {
     return BlocListener<AuthCubit, AuthState>(
@@ -74,9 +65,6 @@ class _SignInScreenState extends State<SignInScreen> {
                 child: BlocBuilder<AuthCubit, AuthState>(
                   builder: (context, state) {
                     final isLoading = state.isLoading;
-                    final obscuredApiKey = state.apiKey == null
-                        ? null
-                        : _maskApiKey(state.apiKey!);
                     return Form(
                       key: _formKey,
                       child: Column(
@@ -88,18 +76,18 @@ class _SignInScreenState extends State<SignInScreen> {
                             style: Theme.of(context).textTheme.titleMedium,
                           ),
                           const SizedBox(height: 16),
-                          if (obscuredApiKey != null)
+                          if (state.hasApiKey)
                             Card(
                               color: Theme.of(context).colorScheme.surfaceVariant,
                               child: Padding(
                                 padding: const EdgeInsets.all(12),
                                 child: Text(
-                                  'Using API key: $obscuredApiKey',
+                                  'TMDB API key configured. You can sign in now.',
                                   style: Theme.of(context).textTheme.bodyMedium,
                                 ),
                               ),
                             ),
-                          if (obscuredApiKey != null) const SizedBox(height: 16),
+                          if (state.hasApiKey) const SizedBox(height: 16),
                           TextFormField(
                             controller: _usernameController,
                             decoration: const InputDecoration(

--- a/lib/features/home/data/repositories/home_repository_impl.dart
+++ b/lib/features/home/data/repositories/home_repository_impl.dart
@@ -16,7 +16,6 @@ class HomeRepositoryImpl extends HomeRepository {
   @override
   Future<MovieTvShowEntity> getDiscoverContent(
     int page,
-    String apiKey,
     String language,
     String category,
     String? region,
@@ -32,7 +31,6 @@ class HomeRepositoryImpl extends HomeRepository {
     final String endpoint = '/discover/$category';
     final params = {
       'page': page,
-      'api_key': apiKey,
       'region': region,
       'language': language,
       'include_adult': false,

--- a/lib/features/home/domain/repositories/home_repository.dart
+++ b/lib/features/home/domain/repositories/home_repository.dart
@@ -3,7 +3,6 @@ import '../../../movies/domain/models/movies_entity.dart';
 abstract class HomeRepository {
   Future<MovieTvShowEntity> getDiscoverContent(
     int page,
-    String apiKey,
     String language,
     String category,
     String? region,

--- a/lib/features/home/domain/usecases/discover_movies/discover_movies_use_case.dart
+++ b/lib/features/home/domain/usecases/discover_movies/discover_movies_use_case.dart
@@ -3,7 +3,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 abstract class DiscoverContentUseCase {
   Future<MovieTvShowEntity> getDiscoverContent({
     required int page,
-    required String apiKey,
     required String language,
     required String category,
     String region,

--- a/lib/features/home/domain/usecases/discover_movies/discover_movies_use_case_impl.dart
+++ b/lib/features/home/domain/usecases/discover_movies/discover_movies_use_case_impl.dart
@@ -10,7 +10,6 @@ class DiscoverContentUseCaseImpl extends DiscoverContentUseCase {
   @override
   Future<MovieTvShowEntity> getDiscoverContent({
     required int page,
-    required String apiKey,
     required String language,
     required String category,
     String? region,
@@ -24,7 +23,6 @@ class DiscoverContentUseCaseImpl extends DiscoverContentUseCase {
   }) async {
     return repository.getDiscoverContent(
       page,
-      apiKey,
       language,
       category,
       region,

--- a/lib/features/home/presentation/bloc/discover_movies/discover_movies_bloc.dart
+++ b/lib/features/home/presentation/bloc/discover_movies/discover_movies_bloc.dart
@@ -6,32 +6,28 @@ import 'package:get_it/get_it.dart';
 import 'package:talker_flutter/talker_flutter.dart';
 import 'package:tmdb_flutter_app/features/movies/domain/usecases/usecases.dart';
 import '../../../../common/common.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'discover_movies_event.dart';
 
 part 'discover_movies_state.dart';
 
 class DiscoverContentBloc extends Bloc<UiEvent, UiState> {
-  DiscoverContentBloc(this.discoverMoviesUseCase, this.authRepository)
+  DiscoverContentBloc(this.discoverMoviesUseCase)
       : super(DiscoverContentLoading()) {
     on<LoadDiscoverContent>(_load);
     on<ToggleSection>(_onToggleSection);
   }
 
   final DiscoverContentUseCase discoverMoviesUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _load(LoadDiscoverContent event, Emitter<UiState> emit) async {
     try {
       if (state is! DiscoverContentLoaded) {
         emit(DiscoverContentLoading());
       }
-      final apiKey = await authRepository.requireApiKey();
 
       final discoverContent = await discoverMoviesUseCase.getDiscoverContent(
         page: 1,
-        apiKey: apiKey,
         language: 'us-US',
         category: event.category,
       );

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:tmdb_flutter_app/core/connection/no_internet_dialog.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 import '../../../common/common.dart';
 import '../../../movies/domain/usecases/trending/trending_movies_use_case.dart';
@@ -25,21 +24,18 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final authRepository = GetIt.I<AuthRepository>();
     return MultiBlocProvider(
       providers: [
         BlocProvider<DiscoverContentBloc>(
           create: (context) =>
               DiscoverContentBloc(
                 GetIt.I<DiscoverContentUseCase>(),
-                authRepository,
               )..add(LoadDiscoverContent(category: 'movie')),
         ),
         BlocProvider<TrendingMoviesBloc>(
           create: (context) =>
               TrendingMoviesBloc(
                 GetIt.I<TrendingMoviesUseCase>(),
-                authRepository,
               )..add(
                 LoadTrendingMovies(
                   selectedPeriod: 'day',

--- a/lib/features/movies/data/repositories/movie_repository_impl.dart
+++ b/lib/features/movies/data/repositories/movie_repository_impl.dart
@@ -20,13 +20,11 @@ class MovieRepositoryImpl extends MovieRepository {
   @override
   // Fetch trending movies. `timeWindow` can be "day" or "week".
   Future<MovieTvShowEntity> getTrendingMovies(
-      String apiKey,
-      String language,
-      String timeWindow,
-      ) async {
+    String language,
+    String timeWindow,
+  ) async {
     final String endpoint = '/trending/movie/$timeWindow';
     final params = {
-      'api_key': apiKey,
       'language': language,
     };
     return _fetchMoviesFromApi(
@@ -39,14 +37,12 @@ class MovieRepositoryImpl extends MovieRepository {
   @override
   Future<MovieTvShowEntity> getPopularMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   ) async {
     final String endpoint = '/movie/popular';
     final params = {
       'page': page,
-      'api_key': apiKey,
       'region': region,
       'language': language,
     };
@@ -60,14 +56,12 @@ class MovieRepositoryImpl extends MovieRepository {
   @override
   Future<MovieTvShowEntity> getNowPlayingMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   ) async {
     final String endpoint = '/movie/now_playing';
     final params = {
       'page': page,
-      'api_key': apiKey,
       'region': region,
       'language': language,
     };
@@ -80,15 +74,13 @@ class MovieRepositoryImpl extends MovieRepository {
 
   @override
   Future<MovieTvShowEntity> getUpcomingMovies(
-      int page,
-      String apiKey,
-      String region,
-      String language,
-      ) async {
+    int page,
+    String region,
+    String language,
+  ) async {
     final String endpoint = '/movie/upcoming';
     final params = {
       'page': page,
-      'api_key': apiKey,
       'region': region,
       'language': language,
     };
@@ -101,15 +93,13 @@ class MovieRepositoryImpl extends MovieRepository {
 
   @override
   Future<MovieTvShowEntity> getTopRatedMovies(
-      int page,
-      String apiKey,
-      String region,
-      String language,
-      ) async {
+    int page,
+    String region,
+    String language,
+  ) async {
     final String endpoint = '/movie/top_rated';
     final params = {
       'page': page,
-      'api_key': apiKey,
       'region': region,
       'language': language,
     };
@@ -123,12 +113,10 @@ class MovieRepositoryImpl extends MovieRepository {
   @override
   Future<MovieDetail> getMovieDetails(
     int movieId,
-    String apiKey,
     String language,
   ) async {
     final endpoint = '/movie/$movieId';
     final params = {
-      'api_key': apiKey,
       'language': language,
     };
     final data = await _fetchJsonFromApi(
@@ -142,12 +130,10 @@ class MovieRepositoryImpl extends MovieRepository {
   @override
   Future<MovieCredits> getMovieCredits(
     int movieId,
-    String apiKey,
     String language,
   ) async {
     final endpoint = '/movie/$movieId/credits';
     final params = {
-      'api_key': apiKey,
       'language': language,
     };
     final data = await _fetchJsonFromApi(
@@ -161,12 +147,10 @@ class MovieRepositoryImpl extends MovieRepository {
   @override
   Future<MovieReviews> getMovieReviews(
     int movieId,
-    String apiKey,
     String language,
   ) async {
     final endpoint = '/movie/$movieId/reviews';
     final params = {
-      'api_key': apiKey,
       'language': language,
       'page': 1,
     };
@@ -181,12 +165,10 @@ class MovieRepositoryImpl extends MovieRepository {
   @override
   Future<MovieRecommendations> getMovieRecommendations(
     int movieId,
-    String apiKey,
     String language,
   ) async {
     final endpoint = '/movie/$movieId/recommendations';
     final params = {
-      'api_key': apiKey,
       'language': language,
       'page': 1,
     };
@@ -201,12 +183,10 @@ class MovieRepositoryImpl extends MovieRepository {
   @override
   Future<MovieWatchProviders> getMovieWatchProviders(
     int movieId,
-    String apiKey,
     String region,
   ) async {
     final endpoint = '/movie/$movieId/watch/providers';
     final params = {
-      'api_key': apiKey,
       'watch_region': region,
     };
     final data = await _fetchJsonFromApi(

--- a/lib/features/movies/domain/repositories/movie_repository.dart
+++ b/lib/features/movies/domain/repositories/movie_repository.dart
@@ -8,66 +8,56 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 abstract class MovieRepository {
 
   Future<MovieTvShowEntity> getTrendingMovies(
-      String apiKey,
-      String language,
-      String timeWindow,
-      );
+    String language,
+    String timeWindow,
+  );
 
   Future<MovieTvShowEntity> getPopularMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   );
 
   Future<MovieTvShowEntity> getNowPlayingMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   );
 
   Future<MovieTvShowEntity> getUpcomingMovies(
-      int page,
-      String apiKey,
-      String region,
-      String language,
-      );
+    int page,
+    String region,
+    String language,
+  );
 
   Future<MovieTvShowEntity> getTopRatedMovies(
-      int page,
-      String apiKey,
-      String region,
-      String language,
-      );
+    int page,
+    String region,
+    String language,
+  );
 
   Future<MovieDetail> getMovieDetails(
     int movieId,
-    String apiKey,
     String language,
   );
 
   Future<MovieCredits> getMovieCredits(
     int movieId,
-    String apiKey,
     String language,
   );
 
   Future<MovieReviews> getMovieReviews(
     int movieId,
-    String apiKey,
     String language,
   );
 
   Future<MovieRecommendations> getMovieRecommendations(
     int movieId,
-    String apiKey,
     String language,
   );
 
   Future<MovieWatchProviders> getMovieWatchProviders(
     int movieId,
-    String apiKey,
     String region,
   );
 }

--- a/lib/features/movies/domain/usecases/details/movie_credits_use_case.dart
+++ b/lib/features/movies/domain/usecases/details/movie_credits_use_case.dart
@@ -3,7 +3,6 @@ import '../../models/movie_credits.dart';
 abstract class MovieCreditsUseCase {
   Future<MovieCredits> getMovieCredits(
     int movieId,
-    String apiKey,
     String language,
   );
 }

--- a/lib/features/movies/domain/usecases/details/movie_credits_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/details/movie_credits_use_case_impl.dart
@@ -10,9 +10,8 @@ class MovieCreditsUseCaseImpl extends MovieCreditsUseCase {
   @override
   Future<MovieCredits> getMovieCredits(
     int movieId,
-    String apiKey,
     String language,
   ) {
-    return repository.getMovieCredits(movieId, apiKey, language);
+    return repository.getMovieCredits(movieId, language);
   }
 }

--- a/lib/features/movies/domain/usecases/details/movie_details_use_case.dart
+++ b/lib/features/movies/domain/usecases/details/movie_details_use_case.dart
@@ -3,7 +3,6 @@ import '../../models/movie_detail.dart';
 abstract class MovieDetailsUseCase {
   Future<MovieDetail> getMovieDetails(
     int movieId,
-    String apiKey,
     String language,
   );
 }

--- a/lib/features/movies/domain/usecases/details/movie_details_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/details/movie_details_use_case_impl.dart
@@ -10,9 +10,8 @@ class MovieDetailsUseCaseImpl extends MovieDetailsUseCase {
   @override
   Future<MovieDetail> getMovieDetails(
     int movieId,
-    String apiKey,
     String language,
   ) {
-    return repository.getMovieDetails(movieId, apiKey, language);
+    return repository.getMovieDetails(movieId, language);
   }
 }

--- a/lib/features/movies/domain/usecases/details/movie_recommendations_use_case.dart
+++ b/lib/features/movies/domain/usecases/details/movie_recommendations_use_case.dart
@@ -3,7 +3,6 @@ import '../../models/movie_recommendations.dart';
 abstract class MovieRecommendationsUseCase {
   Future<MovieRecommendations> getMovieRecommendations(
     int movieId,
-    String apiKey,
     String language,
   );
 }

--- a/lib/features/movies/domain/usecases/details/movie_recommendations_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/details/movie_recommendations_use_case_impl.dart
@@ -10,9 +10,8 @@ class MovieRecommendationsUseCaseImpl extends MovieRecommendationsUseCase {
   @override
   Future<MovieRecommendations> getMovieRecommendations(
     int movieId,
-    String apiKey,
     String language,
   ) {
-    return repository.getMovieRecommendations(movieId, apiKey, language);
+    return repository.getMovieRecommendations(movieId, language);
   }
 }

--- a/lib/features/movies/domain/usecases/details/movie_reviews_use_case.dart
+++ b/lib/features/movies/domain/usecases/details/movie_reviews_use_case.dart
@@ -3,7 +3,6 @@ import '../../models/movie_reviews.dart';
 abstract class MovieReviewsUseCase {
   Future<MovieReviews> getMovieReviews(
     int movieId,
-    String apiKey,
     String language,
   );
 }

--- a/lib/features/movies/domain/usecases/details/movie_reviews_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/details/movie_reviews_use_case_impl.dart
@@ -10,9 +10,8 @@ class MovieReviewsUseCaseImpl extends MovieReviewsUseCase {
   @override
   Future<MovieReviews> getMovieReviews(
     int movieId,
-    String apiKey,
     String language,
   ) {
-    return repository.getMovieReviews(movieId, apiKey, language);
+    return repository.getMovieReviews(movieId, language);
   }
 }

--- a/lib/features/movies/domain/usecases/details/movie_watch_providers_use_case.dart
+++ b/lib/features/movies/domain/usecases/details/movie_watch_providers_use_case.dart
@@ -3,7 +3,6 @@ import '../../models/movie_watch_providers.dart';
 abstract class MovieWatchProvidersUseCase {
   Future<MovieWatchProviders> getMovieWatchProviders(
     int movieId,
-    String apiKey,
     String region,
   );
 }

--- a/lib/features/movies/domain/usecases/details/movie_watch_providers_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/details/movie_watch_providers_use_case_impl.dart
@@ -10,9 +10,8 @@ class MovieWatchProvidersUseCaseImpl extends MovieWatchProvidersUseCase {
   @override
   Future<MovieWatchProviders> getMovieWatchProviders(
     int movieId,
-    String apiKey,
     String region,
   ) {
-    return repository.getMovieWatchProviders(movieId, apiKey, region);
+    return repository.getMovieWatchProviders(movieId, region);
   }
 }

--- a/lib/features/movies/domain/usecases/now_playing/now_playing_movies_use_case.dart
+++ b/lib/features/movies/domain/usecases/now_playing/now_playing_movies_use_case.dart
@@ -3,7 +3,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 abstract class NowPlayingMoviesUseCase {
   Future<MovieTvShowEntity> getNowPlayingMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   );

--- a/lib/features/movies/domain/usecases/now_playing/now_playing_movies_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/now_playing/now_playing_movies_use_case_impl.dart
@@ -11,10 +11,9 @@ class NowPlayingMoviesUseCaseImpl extends NowPlayingMoviesUseCase {
   @override
   Future<MovieTvShowEntity> getNowPlayingMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   ) async {
-    return repository.getNowPlayingMovies(page, apiKey, region, language);
+    return repository.getNowPlayingMovies(page, region, language);
   }
 }

--- a/lib/features/movies/domain/usecases/popular/popular_movies_use_case.dart
+++ b/lib/features/movies/domain/usecases/popular/popular_movies_use_case.dart
@@ -3,7 +3,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 abstract class PopularMoviesUseCase {
   Future<MovieTvShowEntity> getPopularMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   );

--- a/lib/features/movies/domain/usecases/popular/popular_movies_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/popular/popular_movies_use_case_impl.dart
@@ -10,10 +10,9 @@ class PopularMoviesUseCaseImpl extends PopularMoviesUseCase {
   @override
   Future<MovieTvShowEntity> getPopularMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   ) async {
-    return repository.getUpcomingMovies(page, apiKey, region, language);
+    return repository.getPopularMovies(page, region, language);
   }
 }

--- a/lib/features/movies/domain/usecases/top_rated/top_rated_movies_use_case.dart
+++ b/lib/features/movies/domain/usecases/top_rated/top_rated_movies_use_case.dart
@@ -3,7 +3,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 abstract class TopRatedMoviesUseCase {
   Future<MovieTvShowEntity> getTopRatedMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   );

--- a/lib/features/movies/domain/usecases/top_rated/top_rated_movies_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/top_rated/top_rated_movies_use_case_impl.dart
@@ -11,10 +11,9 @@ class TopRatedMoviesUseCaseImpl extends TopRatedMoviesUseCase {
   @override
   Future<MovieTvShowEntity> getTopRatedMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   ) async {
-    return repository.getTopRatedMovies(page, apiKey, region, language);
+    return repository.getTopRatedMovies(page, region, language);
   }
 }

--- a/lib/features/movies/domain/usecases/trending/trending_movies_use_case.dart
+++ b/lib/features/movies/domain/usecases/trending/trending_movies_use_case.dart
@@ -2,7 +2,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 
 abstract class TrendingMoviesUseCase {
   Future<MovieTvShowEntity> getTrendingMovies(
-    String apiKey,
     String language,
     String timeWindow,
   );

--- a/lib/features/movies/domain/usecases/trending/trending_movies_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/trending/trending_movies_use_case_impl.dart
@@ -9,10 +9,9 @@ class TrendingMoviesUseCaseImpl extends TrendingMoviesUseCase {
 
   @override
   Future<MovieTvShowEntity> getTrendingMovies(
-    String apiKey,
     String language,
     String timeWindow,
   ) async {
-    return repository.getTrendingMovies(apiKey, language, timeWindow);
+    return repository.getTrendingMovies(language, timeWindow);
   }
 }

--- a/lib/features/movies/domain/usecases/upcoming/upcoming_movies_use_case.dart
+++ b/lib/features/movies/domain/usecases/upcoming/upcoming_movies_use_case.dart
@@ -3,7 +3,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 abstract class UpcomingMoviesUseCase {
   Future<MovieTvShowEntity> getUpcomingMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   );

--- a/lib/features/movies/domain/usecases/upcoming/upcoming_movies_use_case_impl.dart
+++ b/lib/features/movies/domain/usecases/upcoming/upcoming_movies_use_case_impl.dart
@@ -11,10 +11,9 @@ class UpcomingMoviesUseCaseImpl extends UpcomingMoviesUseCase {
   @override
   Future<MovieTvShowEntity> getUpcomingMovies(
     int page,
-    String apiKey,
     String region,
     String language,
   ) async {
-    return repository.getUpcomingMovies(page, apiKey, region, language);
+    return repository.getUpcomingMovies(page, region, language);
   }
 }

--- a/lib/features/movies/presentation/bloc/movie_details/movie_details_bloc.dart
+++ b/lib/features/movies/presentation/bloc/movie_details/movie_details_bloc.dart
@@ -2,7 +2,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:talker_flutter/talker_flutter.dart';
 
-import '../../../auth/domain/repositories/auth_repository.dart';
 import '../../../common/common.dart';
 import '../../domain/models/movie_credits.dart';
 import '../../domain/models/movie_detail.dart';
@@ -21,7 +20,6 @@ class MovieDetailsBloc extends Bloc<MovieDetailsEvent, MovieDetailsState> {
     required this.movieReviewsUseCase,
     required this.movieRecommendationsUseCase,
     required this.movieWatchProvidersUseCase,
-    required this.authRepository,
   }) : super(MovieDetailsInitial()) {
     on<LoadMovieDetails>(_onLoad);
   }
@@ -31,7 +29,6 @@ class MovieDetailsBloc extends Bloc<MovieDetailsEvent, MovieDetailsState> {
   final MovieReviewsUseCase movieReviewsUseCase;
   final MovieRecommendationsUseCase movieRecommendationsUseCase;
   final MovieWatchProvidersUseCase movieWatchProvidersUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _onLoad(
     LoadMovieDetails event,
@@ -39,35 +36,29 @@ class MovieDetailsBloc extends Bloc<MovieDetailsEvent, MovieDetailsState> {
   ) async {
     emit(MovieDetailsLoading());
     try {
-      final apiKey = await authRepository.requireApiKey();
       final language = event.language ?? 'en-US';
       final region = event.region ?? 'US';
 
       final detail = await movieDetailsUseCase.getMovieDetails(
         event.movieId,
-        apiKey,
         language,
       );
       final credits = await movieCreditsUseCase.getMovieCredits(
         event.movieId,
-        apiKey,
         language,
       );
       final reviews = await movieReviewsUseCase.getMovieReviews(
         event.movieId,
-        apiKey,
         language,
       );
       final recommendations =
           await movieRecommendationsUseCase.getMovieRecommendations(
         event.movieId,
-        apiKey,
         language,
       );
       final watchProviders =
           await movieWatchProvidersUseCase.getMovieWatchProviders(
         event.movieId,
-        apiKey,
         region,
       );
 

--- a/lib/features/movies/presentation/bloc/now_playing/now_playing_movies_bloc.dart
+++ b/lib/features/movies/presentation/bloc/now_playing/now_playing_movies_bloc.dart
@@ -6,21 +6,19 @@ import 'package:talker_flutter/talker_flutter.dart';
 import 'package:tmdb_flutter_app/features/movies/domain/usecases/usecases.dart';
 
 import '../../../../common/common.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'now_playing_movies_event.dart';
 
 part 'now_playing_movies_state.dart';
 
 class NowPlayingMoviesBloc extends Bloc<UiEvent, UiState> {
-  NowPlayingMoviesBloc(this.nowPlayingMoviesUseCase, this.authRepository)
+  NowPlayingMoviesBloc(this.nowPlayingMoviesUseCase)
     : super(NowPlayingMoviesInitial()) {
     on<LoadNowPlayingMovies>(_load);
     on<ToggleSection>(_onToggleSection);
   }
 
   final NowPlayingMoviesUseCase nowPlayingMoviesUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _load(
     LoadNowPlayingMovies event,
@@ -31,10 +29,8 @@ class NowPlayingMoviesBloc extends Bloc<UiEvent, UiState> {
         emit(NowPlayingMoviesLoading());
       }
 
-      final apiKey = await authRepository.requireApiKey();
       final nowPlayingMovies = await nowPlayingMoviesUseCase.getNowPlayingMovies(
         1,
-        apiKey,
         'US',
         'us-US',
       );

--- a/lib/features/movies/presentation/bloc/popular/popular_movies_bloc.dart
+++ b/lib/features/movies/presentation/bloc/popular/popular_movies_bloc.dart
@@ -5,31 +5,27 @@ import 'package:get_it/get_it.dart';
 import 'package:talker_flutter/talker_flutter.dart';
 import 'package:tmdb_flutter_app/features/movies/domain/usecases/usecases.dart';
 import '../../../../common/common.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'popular_movies_event.dart';
 
 part 'popular_movies_state.dart';
 
 class PopularMoviesBloc extends Bloc<UiEvent, UiState> {
-  PopularMoviesBloc(this.popularMoviesUseCase, this.authRepository)
+  PopularMoviesBloc(this.popularMoviesUseCase)
       : super(PopularMoviesInitial()) {
     on<LoadPopularMovies>(_load);
     on<ToggleSection>(_onToggleSection);
   }
 
   final PopularMoviesUseCase popularMoviesUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _load(LoadPopularMovies event, Emitter<UiState> emit) async {
     try {
       if (state is! PopularMoviesLoaded) {
         emit(PopularMoviesLoading());
       }
-      final apiKey = await authRepository.requireApiKey();
       final popularMovies = await popularMoviesUseCase.getPopularMovies(
         1,
-        apiKey,
         'US',
         'us-US',
       );

--- a/lib/features/movies/presentation/bloc/top_rated/top_rated_movies_bloc.dart
+++ b/lib/features/movies/presentation/bloc/top_rated/top_rated_movies_bloc.dart
@@ -6,21 +6,19 @@ import 'package:talker_flutter/talker_flutter.dart';
 import 'package:tmdb_flutter_app/features/movies/domain/usecases/usecases.dart';
 
 import '../../../../common/common.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'top_rated_movies_event.dart';
 
 part 'top_rated_movies_state.dart';
 
 class TopRatedMoviesBloc extends Bloc<UiEvent, UiState> {
-  TopRatedMoviesBloc(this.topRatedMoviesUseCase, this.authRepository)
+  TopRatedMoviesBloc(this.topRatedMoviesUseCase)
     : super(TopRatedMoviesInitial()) {
     on<LoadTopRatedMovies>(_load);
     on<ToggleSection>(_onToggleSection);
   }
 
   final TopRatedMoviesUseCase topRatedMoviesUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _load(
     LoadTopRatedMovies event,
@@ -30,9 +28,8 @@ class TopRatedMoviesBloc extends Bloc<UiEvent, UiState> {
       if (state is! TopRatedMoviesLoaded) {
         emit(TopRatedMoviesLoading());
       }
-      final apiKey = await authRepository.requireApiKey();
       final topRatedMovies = await topRatedMoviesUseCase
-          .getTopRatedMovies(1, apiKey, 'US', 'us-US');
+          .getTopRatedMovies(1, 'US', 'us-US');
       emit(TopRatedMoviesLoaded(topRatedMovies: topRatedMovies, isExpanded: false));
     } catch (e, st) {
       emit(TopRatedMoviesLoadingFailure(exception: e));

--- a/lib/features/movies/presentation/bloc/trending/trending_movies_bloc.dart
+++ b/lib/features/movies/presentation/bloc/trending/trending_movies_bloc.dart
@@ -7,20 +7,18 @@ import 'package:talker_flutter/talker_flutter.dart';
 
 import '../../../domain/usecases/usecases.dart';
 import '../../../../common/common.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'trending_movies_event.dart';
 
 part 'trending_movies_state.dart';
 
 class TrendingMoviesBloc extends Bloc<UiEvent, UiState> {
-  TrendingMoviesBloc(this.trendingMoviesUseCase, this.authRepository)
+  TrendingMoviesBloc(this.trendingMoviesUseCase)
     : super(TrendingMoviesLoading()) {
     on<LoadTrendingMovies>(_load);
   }
 
   final TrendingMoviesUseCase trendingMoviesUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _load(
     LoadTrendingMovies event,
@@ -30,9 +28,7 @@ class TrendingMoviesBloc extends Bloc<UiEvent, UiState> {
       if (state is! TrendingMoviesLoaded) {
         emit(TrendingMoviesLoading());
       }
-      final apiKey = await authRepository.requireApiKey();
       final trendingMovies = await trendingMoviesUseCase.getTrendingMovies(
-        apiKey,
         'us-US',
         event.selectedPeriod,
       );

--- a/lib/features/movies/presentation/bloc/upcoming/upcoming_movies_bloc.dart
+++ b/lib/features/movies/presentation/bloc/upcoming/upcoming_movies_bloc.dart
@@ -6,21 +6,19 @@ import 'package:talker_flutter/talker_flutter.dart';
 import 'package:tmdb_flutter_app/features/movies/domain/usecases/usecases.dart';
 
 import '../../../../common/common.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'upcoming_movies_event.dart';
 
 part 'upcoming_movies_state.dart';
 
 class UpcomingMoviesBloc extends Bloc<UiEvent, UiState> {
-  UpcomingMoviesBloc(this.upcomingMoviesUseCase, this.authRepository)
+  UpcomingMoviesBloc(this.upcomingMoviesUseCase)
     : super(UpcomingMoviesInitial()) {
     on<LoadUpcomingMovies>(_load);
     on<ToggleSection>(_onToggleSection);
   }
 
   final UpcomingMoviesUseCase upcomingMoviesUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _load(
     LoadUpcomingMovies event,
@@ -30,9 +28,8 @@ class UpcomingMoviesBloc extends Bloc<UiEvent, UiState> {
       if (state is! UpcomingMoviesLoaded) {
         emit(UpcomingMoviesLoading());
       }
-      final apiKey = await authRepository.requireApiKey();
       final upcomingMovies = await upcomingMoviesUseCase
-          .getUpcomingMovies(1, apiKey, 'US', 'us-US');
+          .getUpcomingMovies(1, 'US', 'us-US');
       emit(UpcomingMoviesLoaded(upcomingMovies: upcomingMovies, isExpanded: false));
     } catch (e, st) {
       emit(UpcomingMoviesLoadingFailure(exception: e));

--- a/lib/features/movies/presentation/screens/movie_details_screen.dart
+++ b/lib/features/movies/presentation/screens/movie_details_screen.dart
@@ -4,7 +4,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-import '../../../auth/domain/repositories/auth_repository.dart';
 import '../../domain/models/movie.dart';
 import '../../domain/models/movie_credit.dart';
 import '../../domain/models/movie_credits.dart';
@@ -57,7 +56,6 @@ class MovieDetailsScreen extends StatelessWidget {
           movieReviewsUseCase: GetIt.I<MovieReviewsUseCase>(),
           movieRecommendationsUseCase: GetIt.I<MovieRecommendationsUseCase>(),
           movieWatchProvidersUseCase: GetIt.I<MovieWatchProvidersUseCase>(),
-          authRepository: GetIt.I<AuthRepository>(),
         );
         scheduleMicrotask(
           () => bloc.add(LoadMovieDetails(movieId: movieId)),

--- a/lib/features/movies/presentation/screens/movies_screen.dart
+++ b/lib/features/movies/presentation/screens/movies_screen.dart
@@ -2,7 +2,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 import 'package:tmdb_flutter_app/features/movies/presentation/bloc/top_rated/top_rated_movies_bloc.dart';
 
 import '../../../../core/connection/no_internet_dialog.dart';
@@ -25,14 +24,12 @@ class _MoviesScreenState extends State<MoviesScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final authRepository = GetIt.I<AuthRepository>();
     return MultiBlocProvider(
       providers: [
         BlocProvider<TrendingMoviesBloc>(
           create: (context) =>
               TrendingMoviesBloc(
                 GetIt.I<TrendingMoviesUseCase>(),
-                authRepository,
               )..add(
                 LoadTrendingMovies(
                   selectedPeriod: 'day',
@@ -44,28 +41,24 @@ class _MoviesScreenState extends State<MoviesScreen> {
           create: (context) =>
               PopularMoviesBloc(
                 GetIt.I<PopularMoviesUseCase>(),
-                authRepository,
               )..add(LoadPopularMovies()),
         ),
         BlocProvider<NowPlayingMoviesBloc>(
           create: (context) =>
               NowPlayingMoviesBloc(
                 GetIt.I<NowPlayingMoviesUseCase>(),
-                authRepository,
               )..add(LoadNowPlayingMovies()),
         ),
         BlocProvider<UpcomingMoviesBloc>(
           create: (context) =>
               UpcomingMoviesBloc(
                 GetIt.I<UpcomingMoviesUseCase>(),
-                authRepository,
               )..add(LoadUpcomingMovies()),
         ),
         BlocProvider<TopRatedMoviesBloc>(
           create: (context) =>
               TopRatedMoviesBloc(
                 GetIt.I<TopRatedMoviesUseCase>(),
-                authRepository,
               )..add(LoadTopRatedMovies()),
         ),
       ],

--- a/lib/features/tv_shows/data/repositories/tv_shows_repository_impl.dart
+++ b/lib/features/tv_shows/data/repositories/tv_shows_repository_impl.dart
@@ -15,13 +15,11 @@ class TvShowsRepositoryImpl extends TvShowsRepository {
   @override
   // Fetch trending TvShowss. `timeWindow` can be "day" or "week".
   Future<MovieTvShowEntity> getTrendingTvShows(
-      String apiKey,
-      String language,
-      String timeWindow,
-      ) async {
+    String language,
+    String timeWindow,
+  ) async {
     final String endpoint = '/trending/tv/$timeWindow';
     final params = {
-      'api_key': apiKey,
       'language': language,
     };
     return _fetchTvShowsFromApi(
@@ -33,15 +31,13 @@ class TvShowsRepositoryImpl extends TvShowsRepository {
 
   @override
   Future<MovieTvShowEntity> getAiringTodayTvShows(
-      int page,
-      String apiKey,
-      String timezone,
-      String language,
-      ) async {
+    int page,
+    String timezone,
+    String language,
+  ) async {
     final String endpoint = '/tv/airing_today';
     final params = {
       'page': page,
-      'api_key': apiKey,
       'timezone': timezone,
       'language': language,
     };
@@ -54,15 +50,13 @@ class TvShowsRepositoryImpl extends TvShowsRepository {
 
   @override
   Future<MovieTvShowEntity> getOnTheAirTvShows(
-      int page,
-      String apiKey,
-      String region,
-      String language,
-      ) async {
+    int page,
+    String region,
+    String language,
+  ) async {
     final String endpoint = '/tv/on_the_air';
     final params = {
       'page': page,
-      'api_key': apiKey,
       'region': region,
       'language': language,
     };
@@ -76,14 +70,12 @@ class TvShowsRepositoryImpl extends TvShowsRepository {
   @override
   Future<MovieTvShowEntity> getPopularTvShows(
     int page,
-    String apiKey,
     String region,
     String language,
   ) async {
     final String endpoint = '/tv/popular';
     final params = {
       'page': page,
-      'api_key': apiKey,
       'region': region,
       'language': language,
     };
@@ -96,15 +88,13 @@ class TvShowsRepositoryImpl extends TvShowsRepository {
 
   @override
   Future<MovieTvShowEntity> getTopRatedTvShows(
-      int page,
-      String apiKey,
-      String region,
-      String language,
-      ) async {
+    int page,
+    String region,
+    String language,
+  ) async {
     final String endpoint = '/tv/top_rated';
     final params = {
       'page': page,
-      'api_key': apiKey,
       'region': region,
       'language': language,
     };

--- a/lib/features/tv_shows/domain/repositories/tv_shows_repository.dart
+++ b/lib/features/tv_shows/domain/repositories/tv_shows_repository.dart
@@ -3,36 +3,31 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 abstract class TvShowsRepository {
 
   Future<MovieTvShowEntity> getTrendingTvShows(
-      String apiKey,
-      String language,
-      String timeWindow,
-      );
+    String language,
+    String timeWindow,
+  );
 
   Future<MovieTvShowEntity> getAiringTodayTvShows(
     int page,
-    String apiKey,
     String region,
     String language,
   );
 
   Future<MovieTvShowEntity> getOnTheAirTvShows(
-      int page,
-      String apiKey,
-      String region,
-      String language,
-      );
+    int page,
+    String region,
+    String language,
+  );
 
   Future<MovieTvShowEntity> getPopularTvShows(
-      int page,
-      String apiKey,
-      String region,
-      String language,
-      );
+    int page,
+    String region,
+    String language,
+  );
 
   Future<MovieTvShowEntity> getTopRatedTvShows(
-      int page,
-      String apiKey,
-      String region,
-      String language,
-      );
+    int page,
+    String region,
+    String language,
+  );
 }

--- a/lib/features/tv_shows/domain/usecases/airing_today/airing_today_tv_shows_use_case.dart
+++ b/lib/features/tv_shows/domain/usecases/airing_today/airing_today_tv_shows_use_case.dart
@@ -3,7 +3,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 abstract class AiringTodayTvShowsUseCase {
   Future<MovieTvShowEntity> getAiringTodayTvShows(
     int page,
-    String apiKey,
     String timezone,
     String language,
   );

--- a/lib/features/tv_shows/domain/usecases/airing_today/airing_today_tv_shows_use_case_impl.dart
+++ b/lib/features/tv_shows/domain/usecases/airing_today/airing_today_tv_shows_use_case_impl.dart
@@ -10,10 +10,9 @@ class AiringTodayTvShowsUseCaseImpl extends AiringTodayTvShowsUseCase {
   @override
   Future<MovieTvShowEntity> getAiringTodayTvShows(
     int page,
-    String apiKey,
     String timezone,
     String language,
   ) async {
-    return repository.getAiringTodayTvShows(page, apiKey, timezone, language);
+    return repository.getAiringTodayTvShows(page, timezone, language);
   }
 }

--- a/lib/features/tv_shows/domain/usecases/popular/popular_tv_shows_use_case.dart
+++ b/lib/features/tv_shows/domain/usecases/popular/popular_tv_shows_use_case.dart
@@ -3,7 +3,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 abstract class PopularTvShowsUseCase {
   Future<MovieTvShowEntity> getPopularTvShows(
     int page,
-    String apiKey,
     String region,
     String language,
   );

--- a/lib/features/tv_shows/domain/usecases/popular/popular_tv_shows_use_case_impl.dart
+++ b/lib/features/tv_shows/domain/usecases/popular/popular_tv_shows_use_case_impl.dart
@@ -10,10 +10,9 @@ class PopularTvShowsUseCaseImpl extends PopularTvShowsUseCase {
   @override
   Future<MovieTvShowEntity> getPopularTvShows(
     int page,
-    String apiKey,
     String region,
     String language,
   ) async {
-    return repository.getPopularTvShows(page, apiKey, region, language);
+    return repository.getPopularTvShows(page, region, language);
   }
 }

--- a/lib/features/tv_shows/domain/usecases/top_rated/top_rated_tv_shows_use_case.dart
+++ b/lib/features/tv_shows/domain/usecases/top_rated/top_rated_tv_shows_use_case.dart
@@ -3,7 +3,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 abstract class TopRatedTvShowsUseCase {
   Future<MovieTvShowEntity> getTopRatedTvShows(
     int page,
-    String apiKey,
     String region,
     String language,
   );

--- a/lib/features/tv_shows/domain/usecases/top_rated/top_rated_tv_shows_use_case_impl.dart
+++ b/lib/features/tv_shows/domain/usecases/top_rated/top_rated_tv_shows_use_case_impl.dart
@@ -10,10 +10,9 @@ class TopRatedTvShowsUseCaseImpl extends TopRatedTvShowsUseCase {
   @override
   Future<MovieTvShowEntity> getTopRatedTvShows(
     int page,
-    String apiKey,
     String region,
     String language,
   ) async {
-    return repository.getTopRatedTvShows(page, apiKey, region, language);
+    return repository.getTopRatedTvShows(page, region, language);
   }
 }

--- a/lib/features/tv_shows/domain/usecases/trending/trending_tv_shows_use_case.dart
+++ b/lib/features/tv_shows/domain/usecases/trending/trending_tv_shows_use_case.dart
@@ -2,7 +2,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 
 abstract class TrendingTvShowsUseCase {
   Future<MovieTvShowEntity> getTrendingTvShows(
-    String apiKey,
     String language,
     String timeWindow,
   );

--- a/lib/features/tv_shows/domain/usecases/trending/trending_tv_shows_use_case_impl.dart
+++ b/lib/features/tv_shows/domain/usecases/trending/trending_tv_shows_use_case_impl.dart
@@ -9,10 +9,9 @@ class TrendingTvShowsUseCaseImpl extends TrendingTvShowsUseCase {
 
   @override
   Future<MovieTvShowEntity> getTrendingTvShows(
-    String apiKey,
     String language,
     String timeWindow,
   ) async {
-    return repository.getTrendingTvShows(apiKey, language, timeWindow);
+    return repository.getTrendingTvShows(language, timeWindow);
   }
 }

--- a/lib/features/tv_shows/presentation/bloc/airing_today/airing_today_tv_shows_bloc.dart
+++ b/lib/features/tv_shows/presentation/bloc/airing_today/airing_today_tv_shows_bloc.dart
@@ -6,21 +6,19 @@ import 'package:talker_flutter/talker_flutter.dart';
 import '../../../../../features/common/common.dart';
 import '../../../../movies/domain/models/movies_entity.dart';
 import '../../../domain/usecases/airing_today/airing_today_tv_shows_use_case.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'airing_today_tv_shows_event.dart';
 
 part 'airing_today_tv_shows_state.dart';
 
 class AiringTodayTvShowsBloc extends Bloc<UiEvent, UiState> {
-  AiringTodayTvShowsBloc(this.airingTodayTvShowsUseCase, this.authRepository)
+  AiringTodayTvShowsBloc(this.airingTodayTvShowsUseCase)
     : super(AiringTodayTvShowsInitial()) {
     on<LoadAiringTodayTvShows>(_load);
     on<ToggleSection>(_onToggleSection);
   }
 
   final AiringTodayTvShowsUseCase airingTodayTvShowsUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _load(
     LoadAiringTodayTvShows event,
@@ -30,10 +28,8 @@ class AiringTodayTvShowsBloc extends Bloc<UiEvent, UiState> {
       if (state is! AiringTodayTvShowsLoaded) {
         emit(AiringTodayTvShowsLoading());
       }
-      final apiKey = await authRepository.requireApiKey();
-
       final airingTodayTvShows = await airingTodayTvShowsUseCase
-          .getAiringTodayTvShows(1, apiKey, 'US', 'us-US');
+          .getAiringTodayTvShows(1, 'US', 'us-US');
 
       emit(
         AiringTodayTvShowsLoaded(

--- a/lib/features/tv_shows/presentation/bloc/popular/popular_tv_shows_bloc.dart
+++ b/lib/features/tv_shows/presentation/bloc/popular/popular_tv_shows_bloc.dart
@@ -6,31 +6,27 @@ import 'package:talker_flutter/talker_flutter.dart';
 import '../../../../../features/common/common.dart';
 import '../../../../movies/domain/models/movies_entity.dart';
 import '../../../domain/usecases/popular/popular_tv_shows_use_case.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'popular_tv_shows_event.dart';
 
 part 'popular_tv_shows_state.dart';
 
 class PopularTvShowsBloc extends Bloc<UiEvent, UiState> {
-  PopularTvShowsBloc(this.popularTvShowsUseCase, this.authRepository)
+  PopularTvShowsBloc(this.popularTvShowsUseCase)
     : super(PopularTvShowsInitial()) {
     on<LoadPopularTvShows>(_load);
     on<ToggleSection>(_onToggleSection);
   }
 
   final PopularTvShowsUseCase popularTvShowsUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _load(LoadPopularTvShows event, Emitter<UiState> emit) async {
     try {
       if (state is! PopularTvShowsLoaded) {
         emit(PopularTvShowsLoading());
       }
-      final apiKey = await authRepository.requireApiKey();
       final popularTvShows = await popularTvShowsUseCase.getPopularTvShows(
         1,
-        apiKey,
         'US',
         'us-US',
       );

--- a/lib/features/tv_shows/presentation/bloc/top_rated/top_rated_tv_shows_bloc.dart
+++ b/lib/features/tv_shows/presentation/bloc/top_rated/top_rated_tv_shows_bloc.dart
@@ -7,31 +7,27 @@ import 'package:talker_flutter/talker_flutter.dart';
 import '../../../../common/common.dart';
 import '../../../../movies/domain/models/movies_entity.dart';
 import '../../../domain/usecases/top_rated/top_rated_tv_shows_use_case.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'top_rated_tv_shows_event.dart';
 
 part 'top_rated_tv_shows_state.dart';
 
 class TopRatedTvShowsBloc extends Bloc<UiEvent, UiState> {
-  TopRatedTvShowsBloc(this.topRatedTvShowsUseCase, this.authRepository)
+  TopRatedTvShowsBloc(this.topRatedTvShowsUseCase)
     : super(TopRatedTvShowsInitial()) {
     on<LoadTopRatedTvShows>(_load);
     on<ToggleSection>(_onToggleSection);
   }
 
   final TopRatedTvShowsUseCase topRatedTvShowsUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _load(LoadTopRatedTvShows event, Emitter<UiState> emit) async {
     try {
       if (state is! TopRatedTvShowsLoaded) {
         emit(TopRatedTvShowsLoading());
       }
-      final apiKey = await authRepository.requireApiKey();
       final topRatedTvShows = await topRatedTvShowsUseCase.getTopRatedTvShows(
         1,
-        apiKey,
         'US',
         'us-US',
       );

--- a/lib/features/tv_shows/presentation/bloc/trending/trending_tv_shows_bloc.dart
+++ b/lib/features/tv_shows/presentation/bloc/trending/trending_tv_shows_bloc.dart
@@ -8,30 +8,25 @@ import 'package:talker_flutter/talker_flutter.dart';
 import '../../../../common/common.dart';
 import '../../../../movies/domain/models/movies_entity.dart';
 import '../../../domain/usecases/trending/trending_tv_shows_use_case.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 part 'trending_tv_shows_event.dart';
 
 part 'trending_tv_shows_state.dart';
 
 class TrendingTvShowsBloc extends Bloc<UiEvent, UiState> {
-  TrendingTvShowsBloc(this.trendingTvShowsUseCase, this.authRepository)
+  TrendingTvShowsBloc(this.trendingTvShowsUseCase)
     : super(TrendingTvShowsLoading()) {
     on<LoadTrendingTvShows>(_load);
   }
 
   final TrendingTvShowsUseCase trendingTvShowsUseCase;
-  final AuthRepository authRepository;
 
   Future<void> _load(LoadTrendingTvShows event, Emitter<UiState> emit) async {
     try {
       if (state is! TrendingTvShowsLoaded) {
         emit(TrendingTvShowsLoading());
       }
-      final apiKey = await authRepository.requireApiKey();
-
       final trendingTvShows = await trendingTvShowsUseCase.getTrendingTvShows(
-        apiKey,
         'us-US',
         event.selectedPeriod,
       );

--- a/lib/features/tv_shows/presentation/screens/tv_shows_screen.dart
+++ b/lib/features/tv_shows/presentation/screens/tv_shows_screen.dart
@@ -2,7 +2,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 import 'package:tmdb_flutter_app/features/tv_shows/presentation/bloc/airing_today/airing_today_tv_shows_bloc.dart';
 import 'package:tmdb_flutter_app/features/tv_shows/presentation/widgets/tv_shows_screen_content.dart';
 
@@ -27,35 +26,30 @@ class _TvShowsScreenState extends State<TvShowsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final authRepository = GetIt.I<AuthRepository>();
     return MultiBlocProvider(
       providers: [
         BlocProvider<TrendingTvShowsBloc>(
           create: (context) =>
               TrendingTvShowsBloc(
                 GetIt.I<TrendingTvShowsUseCase>(),
-                authRepository,
               )..add(LoadTrendingTvShows(selectedPeriod: 'day')),
         ),
         BlocProvider<PopularTvShowsBloc>(
           create: (context) =>
               PopularTvShowsBloc(
                 GetIt.I<PopularTvShowsUseCase>(),
-                authRepository,
               )..add(LoadPopularTvShows()),
         ),
         BlocProvider<TopRatedTvShowsBloc>(
           create: (context) =>
               TopRatedTvShowsBloc(
                 GetIt.I<TopRatedTvShowsUseCase>(),
-                authRepository,
               )..add(LoadTopRatedTvShows()),
         ),
         BlocProvider<AiringTodayTvShowsBloc>(
           create: (context) =>
               AiringTodayTvShowsBloc(
                 GetIt.I<AiringTodayTvShowsUseCase>(),
-                authRepository,
               )..add(LoadAiringTodayTvShows()),
         )
       ],

--- a/test/features/actors/data/actors_repository_impl_test.dart
+++ b/test/features/actors/data/actors_repository_impl_test.dart
@@ -45,12 +45,10 @@ void main() {
   });
 
   group('ActorsRepositoryImpl caching', () {
-    const apiKey = 'api-key';
     const language = 'en-US';
     const actorId = 42;
     final endpoint = '/person/$actorId';
     final params = <String, dynamic>{
-      'api_key': apiKey,
       'language': language,
     };
 
@@ -76,7 +74,7 @@ void main() {
 
       await store.set(cachedResponse);
 
-      final result = await repository.getActorDetails(actorId, apiKey, language);
+      final result = await repository.getActorDetails(actorId, language);
 
       expect(result, isA<ActorDetails>());
       expect(result.id, actorId);
@@ -142,7 +140,7 @@ void main() {
         ),
       );
 
-      final result = await repository.getActorDetails(actorId, apiKey, language);
+      final result = await repository.getActorDetails(actorId, language);
 
       expect(result.name, 'Fresh Name');
       verify(

--- a/test/features/actors/presentation/bloc/actor_details_bloc_test.dart
+++ b/test/features/actors/presentation/bloc/actor_details_bloc_test.dart
@@ -26,9 +26,9 @@ void main() {
     blocTest<ActorDetailsBloc, ActorDetailsState>(
       'emits [loading, loaded] when use case succeeds',
       build: () {
-        when(() => useCase.getActorDetails(any(), any(), any()))
+        when(() => useCase.getActorDetails(any(), any()))
             .thenAnswer((_) async => actorDetails);
-        return ActorDetailsBloc(useCase)..apiKey = 'abc';
+        return ActorDetailsBloc(useCase);
       },
       act: (bloc) => bloc.add(LoadActorDetails(actorId: actorDetails.id)),
       expect: () => [
@@ -36,7 +36,7 @@ void main() {
         ActorDetailsLoaded(actorDetails: actorDetails),
       ],
       verify: (_) {
-        verify(() => useCase.getActorDetails(actorDetails.id, any(), any()))
+        verify(() => useCase.getActorDetails(actorDetails.id, any()))
             .called(1);
       },
     );
@@ -44,9 +44,9 @@ void main() {
     blocTest<ActorDetailsBloc, ActorDetailsState>(
       'emits [loading, failure] when use case throws',
       build: () {
-        when(() => useCase.getActorDetails(any(), any(), any()))
+        when(() => useCase.getActorDetails(any(), any()))
             .thenThrow(Exception('boom'));
-        return ActorDetailsBloc(useCase)..apiKey = 'abc';
+        return ActorDetailsBloc(useCase);
       },
       act: (bloc) => bloc.add(LoadActorDetails(actorId: actorDetails.id)),
       expect: () => [
@@ -54,7 +54,7 @@ void main() {
         isA<ActorDetailsFailure>(),
       ],
       verify: (_) {
-        verify(() => useCase.getActorDetails(actorDetails.id, any(), any()))
+        verify(() => useCase.getActorDetails(actorDetails.id, any()))
             .called(1);
       },
     );

--- a/test/features/home/data/home_repository_impl_test.dart
+++ b/test/features/home/data/home_repository_impl_test.dart
@@ -46,7 +46,6 @@ void main() {
 
   group('HomeRepositoryImpl caching', () {
     test('returns cached discover content without network call', () async {
-      const apiKey = 'api-key';
       const language = 'en-US';
       const category = 'movie';
       const region = 'US';
@@ -54,7 +53,6 @@ void main() {
       final endpoint = '/discover/$category';
       final params = <String, dynamic>{
         'page': page,
-        'api_key': apiKey,
         'region': region,
         'language': language,
         'include_adult': false,
@@ -106,7 +104,6 @@ void main() {
 
       final result = await repository.getDiscoverContent(
         page,
-        apiKey,
         language,
         category,
         region,

--- a/test/features/movies/data/movie_repository_impl_test.dart
+++ b/test/features/movies/data/movie_repository_impl_test.dart
@@ -46,12 +46,10 @@ void main() {
 
   group('MovieRepositoryImpl caching', () {
     test('returns cached trending movies without network call', () async {
-      const apiKey = 'api-key';
       const language = 'en-US';
       const timeWindow = 'day';
       final endpoint = '/trending/movie/$timeWindow';
       final params = <String, dynamic>{
-        'api_key': apiKey,
         'language': language,
       };
 
@@ -99,7 +97,7 @@ void main() {
       await store.set(cachedResponse);
 
       final result =
-          await repository.getTrendingMovies(apiKey, language, timeWindow);
+          await repository.getTrendingMovies(language, timeWindow);
 
       expect(result, isA<MovieTvShowEntity>());
       expect(result.results, isNotNull);

--- a/test/features/tv_shows/data/tv_shows_repository_impl_test.dart
+++ b/test/features/tv_shows/data/tv_shows_repository_impl_test.dart
@@ -46,12 +46,10 @@ void main() {
 
   group('TvShowsRepositoryImpl caching', () {
     test('returns cached trending tv shows without network call', () async {
-      const apiKey = 'api-key';
       const language = 'en-US';
       const timeWindow = 'day';
       final endpoint = '/trending/tv/$timeWindow';
       final params = <String, dynamic>{
-        'api_key': apiKey,
         'language': language,
       };
 
@@ -99,7 +97,7 @@ void main() {
       await store.set(cachedResponse);
 
       final result =
-          await repository.getTrendingTvShows(apiKey, language, timeWindow);
+          await repository.getTrendingTvShows(language, timeWindow);
 
       expect(result, isA<MovieTvShowEntity>());
       expect(result.results, isNotNull);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,6 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 import 'package:tmdb_flutter_app/features/movies/domain/usecases/trending/trending_movies_use_case.dart';
 import 'package:tmdb_flutter_app/tmdb_flutter_app.dart';
 import 'package:tmdb_flutter_app/features/auth/domain/entities/auth_session.dart';
-import 'package:tmdb_flutter_app/features/auth/domain/exceptions/auth_exception.dart';
 import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
 class _FakeDiscoverContentUseCase extends DiscoverContentUseCase {
@@ -19,7 +18,6 @@ class _FakeDiscoverContentUseCase extends DiscoverContentUseCase {
   @override
   Future<MovieTvShowEntity> getDiscoverContent({
     required int page,
-    required String apiKey,
     required String language,
     required String category,
     String? region,
@@ -42,7 +40,6 @@ class _FakeTrendingMoviesUseCase extends TrendingMoviesUseCase {
 
   @override
   Future<MovieTvShowEntity> getTrendingMovies(
-    String apiKey,
     String language,
     String timeWindow,
   ) async {
@@ -156,15 +153,6 @@ class _FakeAuthRepository implements AuthRepository {
 
   @override
   Future<AuthSession?> getSession() async => _session;
-
-  @override
-  Future<String> requireApiKey() async {
-    final apiKey = _apiKey;
-    if (apiKey == null) {
-      throw AuthException('Missing API key');
-    }
-    return apiKey;
-  }
 
   @override
   Future<void> saveApiKey(String apiKey) async {


### PR DESCRIPTION
## Summary
- remove explicit apiKey arguments from movie, TV, actor, and home repositories and use cases, eliminating `authRepository.requireApiKey()` usage in blocs
- update presentation layer and auth cubit/state to track configuration via a boolean flag instead of storing API keys, and adjust auth remote calls to send bearer headers
- refresh tests and fakes to match the new method signatures and parameter lists

## Testing
- `flutter test` *(fails: flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a65f6c588323914aa8d319b648ab