### PR TITLE
Add auth interceptor with token refresh handling

### DIFF
--- a/lib/features/auth/data/datasources/auth_local_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_local_data_source.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../../domain/entities/auth_session.dart';
+import '../../domain/entities/auth_tokens.dart';
 
 class AuthLocalDataSource {
   AuthLocalDataSource({required FlutterSecureStorage storage})
@@ -11,6 +12,8 @@ class AuthLocalDataSource {
   static const _apiKeyStorageKey = 'tmdb_api_key';
   static const _sessionIdStorageKey = 'tmdb_session_id';
   static const _accountIdStorageKey = 'tmdb_account_id';
+  static const _accessTokenStorageKey = 'tmdb_access_token';
+  static const _refreshTokenStorageKey = 'tmdb_refresh_token';
 
   Future<void> saveApiKey(String apiKey) async {
     await _storage.write(key: _apiKeyStorageKey, value: apiKey);
@@ -45,5 +48,36 @@ class AuthLocalDataSource {
   Future<void> clearSession() async {
     await _storage.delete(key: _sessionIdStorageKey);
     await _storage.delete(key: _accountIdStorageKey);
+  }
+
+  Future<void> saveTokens(AuthTokens tokens) async {
+    await _storage.write(
+      key: _accessTokenStorageKey,
+      value: tokens.accessToken,
+    );
+    await _storage.write(
+      key: _refreshTokenStorageKey,
+      value: tokens.refreshToken,
+    );
+  }
+
+  Future<AuthTokens?> getTokens() async {
+    final accessToken = await _storage.read(key: _accessTokenStorageKey);
+    final refreshToken = await _storage.read(key: _refreshTokenStorageKey);
+
+    if (accessToken == null || accessToken.isEmpty) {
+      return null;
+    }
+
+    if (refreshToken == null || refreshToken.isEmpty) {
+      return null;
+    }
+
+    return AuthTokens(accessToken: accessToken, refreshToken: refreshToken);
+  }
+
+  Future<void> clearTokens() async {
+    await _storage.delete(key: _accessTokenStorageKey);
+    await _storage.delete(key: _refreshTokenStorageKey);
   }
 }

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 
+import '../../domain/entities/auth_tokens.dart';
 import '../models/account_response.dart';
 import '../models/request_token_response.dart';
 import '../models/session_response.dart';
@@ -74,6 +75,24 @@ class AuthRemoteDataSource {
       },
     );
     return AccountResponse.fromJson(_mapResponse(response.data));
+  }
+
+  Future<AuthTokens> refreshTokens({required String refreshToken}) async {
+    final response = await _dio.post(
+      '/authentication/token/refresh',
+      data: {'refresh_token': refreshToken},
+    );
+    final data = _mapResponse(response.data);
+    final accessToken = (data['access_token'] as String?) ?? '';
+    final newRefreshToken = (data['refresh_token'] as String?) ?? '';
+    if (accessToken.isEmpty || newRefreshToken.isEmpty) {
+      throw DioException(
+        requestOptions: RequestOptions(path: '/authentication/token/refresh'),
+        type: DioExceptionType.badResponse,
+        error: 'Missing tokens in refresh response',
+      );
+    }
+    return AuthTokens(accessToken: accessToken, refreshToken: newRefreshToken);
   }
 
   Map<String, dynamic> _mapResponse(dynamic data) {

--- a/lib/features/auth/data/interceptors/auth_interceptor.dart
+++ b/lib/features/auth/data/interceptors/auth_interceptor.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+
+import '../../domain/entities/auth_tokens.dart';
+import '../../domain/repositories/auth_repository.dart';
+
+class AuthInterceptor extends Interceptor {
+  AuthInterceptor({
+    required Dio dio,
+    required AuthRepository Function() authRepositoryProvider,
+  })  : _dio = dio,
+        _authRepositoryProvider = authRepositoryProvider;
+
+  static const _retryExtraKey = 'auth_retry';
+
+  final Dio _dio;
+  final AuthRepository Function() _authRepositoryProvider;
+  Completer<AuthTokens?>? _refreshCompleter;
+
+  AuthRepository get _authRepository => _authRepositoryProvider();
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
+    try {
+      final token = await _authRepository.getAccessToken();
+      if (token != null && token.isNotEmpty) {
+        options.headers['Authorization'] = 'Bearer $token';
+      }
+    } catch (_) {
+      // Ignore token loading failures and continue without auth header.
+    }
+    handler.next(options);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) async {
+    final response = err.response;
+    final statusCode = response?.statusCode;
+    final alreadyRetried = err.requestOptions.extra[_retryExtraKey] == true;
+
+    if (statusCode == 401 && !alreadyRetried) {
+      try {
+        final tokens = await _refreshTokens();
+        if (tokens == null || !tokens.hasAccessToken) {
+          await _handleRefreshFailure();
+          handler.next(err);
+          return;
+        }
+
+        await _authRepository.saveTokens(tokens);
+        final updatedHeaders = Map<String, dynamic>.from(err.requestOptions.headers)
+          ..['Authorization'] = 'Bearer ${tokens.accessToken}';
+        final updatedExtra = Map<String, dynamic>.from(err.requestOptions.extra)
+          ..[_retryExtraKey] = true;
+
+        final requestOptions = err.requestOptions.copyWith(
+          headers: updatedHeaders,
+          extra: updatedExtra,
+        );
+
+        try {
+          final response = await _dio.fetch<dynamic>(requestOptions);
+          handler.resolve(response);
+          return;
+        } on DioException catch (dioError) {
+          handler.next(dioError);
+          return;
+        }
+      } catch (_) {
+        await _handleRefreshFailure();
+        handler.next(err);
+        return;
+      }
+    }
+
+    handler.next(err);
+  }
+
+  Future<AuthTokens?> _refreshTokens() {
+    final existingCompleter = _refreshCompleter;
+    if (existingCompleter != null) {
+      return existingCompleter.future;
+    }
+
+    final completer = Completer<AuthTokens?>();
+    _refreshCompleter = completer;
+
+    () async {
+      try {
+        final tokens = await _authRepository.refreshTokens();
+        completer.complete(tokens);
+      } catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      } finally {
+        _refreshCompleter = null;
+      }
+    }();
+
+    return completer.future;
+  }
+
+  Future<void> _handleRefreshFailure() async {
+    await _authRepository.clearTokens();
+    _authRepository.notifyLogout();
+  }
+}

--- a/lib/features/auth/domain/entities/auth_tokens.dart
+++ b/lib/features/auth/domain/entities/auth_tokens.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+
+class AuthTokens extends Equatable {
+  const AuthTokens({
+    required this.accessToken,
+    required this.refreshToken,
+  });
+
+  final String accessToken;
+  final String refreshToken;
+
+  bool get hasAccessToken => accessToken.isNotEmpty;
+
+  @override
+  List<Object?> get props => [accessToken, refreshToken];
+
+  AuthTokens copyWith({
+    String? accessToken,
+    String? refreshToken,
+  }) {
+    return AuthTokens(
+      accessToken: accessToken ?? this.accessToken,
+      refreshToken: refreshToken ?? this.refreshToken,
+    );
+  }
+}

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -1,5 +1,7 @@
 import '../entities/auth_session.dart';
 
+import '../entities/auth_tokens.dart';
+
 abstract class AuthRepository {
   Future<String?> getApiKey();
 
@@ -8,6 +10,20 @@ abstract class AuthRepository {
   Future<void> clearApiKey();
 
   Future<bool> validateApiKey(String apiKey);
+
+  Future<String?> getAccessToken();
+
+  Future<AuthTokens?> getTokens();
+
+  Future<void> saveTokens(AuthTokens tokens);
+
+  Future<void> clearTokens();
+
+  Future<AuthTokens?> refreshTokens();
+
+  Stream<void> get logoutStream;
+
+  void notifyLogout();
 
   Future<AuthSession?> getSession();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ import 'features/tv_shows/domain/usecases/usecases.dart';
 import 'features/tv_shows/domain/repositories/tv_shows_repository.dart';
 import 'features/auth/data/datasources/auth_local_data_source.dart';
 import 'features/auth/data/datasources/auth_remote_data_source.dart';
+import 'features/auth/data/interceptors/auth_interceptor.dart';
 import 'features/auth/data/repositories/auth_repository_impl.dart';
 import 'features/auth/domain/repositories/auth_repository.dart';
 
@@ -241,6 +242,11 @@ Future<Dio> buildDio() async {
   di.registerSingleton<CacheOptions>(cacheOptions);
   final cacheInterceptor = DioCacheInterceptor(options: cacheOptions);
 
+  final authInterceptor = AuthInterceptor(
+    dio: dio,
+    authRepositoryProvider: () => GetIt.I<AuthRepository>(),
+  );
+
   dio.interceptors.addAll([
     cacheInterceptor,
     ConnectionInterceptor(),
@@ -250,6 +256,7 @@ Future<Dio> buildDio() async {
         printResponseData: true,
       ),
     ),
+    authInterceptor,
     // Retries with exponential backoff (no retry on 4xx)
     RetryInterceptor(
       dio: dio,

--- a/test/features/auth/data/interceptors/auth_interceptor_test.dart
+++ b/test/features/auth/data/interceptors/auth_interceptor_test.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:tmdb_flutter_app/features/auth/data/interceptors/auth_interceptor.dart';
+import 'package:tmdb_flutter_app/features/auth/domain/entities/auth_tokens.dart';
+import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+class _TestAdapter extends HttpClientAdapter {
+  _TestAdapter(this.onFetch);
+
+  final Future<ResponseBody> Function(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) onFetch;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    return onFetch(options, requestStream, cancelFuture);
+  }
+}
+
+void main() {
+  late Dio dio;
+  late _MockAuthRepository authRepository;
+
+  setUpAll(() {
+    registerFallbackValue(
+      const AuthTokens(accessToken: '', refreshToken: ''),
+    );
+  });
+
+  setUp(() {
+    dio = Dio(BaseOptions(baseUrl: 'https://example.com'));
+    authRepository = _MockAuthRepository();
+    dio.interceptors.add(
+      AuthInterceptor(
+        dio: dio,
+        authRepositoryProvider: () => authRepository,
+      ),
+    );
+  });
+
+  test('adds bearer token header when access token available', () async {
+    when(() => authRepository.getAccessToken()).thenAnswer((_) async => 'token');
+
+    late RequestOptions capturedOptions;
+    dio.httpClientAdapter = _TestAdapter((options, __, ___) async {
+      capturedOptions = options;
+      return ResponseBody.fromString(
+        '{}',
+        200,
+        headers: {
+          Headers.contentTypeHeader: ['application/json'],
+        },
+      );
+    });
+
+    final response = await dio.get('/movies');
+
+    expect(response.statusCode, 200);
+    expect(capturedOptions.headers['Authorization'], 'Bearer token');
+    verify(() => authRepository.getAccessToken()).called(1);
+  });
+
+  test('refreshes tokens and retries the original request on 401', () async {
+    when(() => authRepository.getAccessToken()).thenAnswer((_) async => 'expired');
+    when(() => authRepository.refreshTokens()).thenAnswer(
+      (_) async => const AuthTokens(accessToken: 'new-token', refreshToken: 'refresh'),
+    );
+    when(() => authRepository.saveTokens(any())).thenAnswer((_) async {});
+
+    var callCount = 0;
+    dio.httpClientAdapter = _TestAdapter((options, __, ___) async {
+      callCount += 1;
+      if (callCount == 1) {
+        return ResponseBody.fromString(
+          '{}',
+          401,
+          headers: {
+            Headers.contentTypeHeader: ['application/json'],
+          },
+        );
+      }
+
+      expect(options.headers['Authorization'], 'Bearer new-token');
+      return ResponseBody.fromString(
+        '{}',
+        200,
+        headers: {
+          Headers.contentTypeHeader: ['application/json'],
+        },
+      );
+    });
+
+    final response = await dio.get('/protected');
+
+    expect(response.statusCode, 200);
+    expect(callCount, 2);
+    verify(() => authRepository.refreshTokens()).called(1);
+    verify(() => authRepository.saveTokens(const AuthTokens(accessToken: 'new-token', refreshToken: 'refresh'))).called(1);
+    verifyNever(() => authRepository.clearTokens());
+  });
+
+  test('clears tokens and notifies logout when refresh fails', () async {
+    when(() => authRepository.getAccessToken()).thenAnswer((_) async => 'expired');
+    when(() => authRepository.refreshTokens()).thenThrow(Exception('fail'));
+    when(() => authRepository.clearTokens()).thenAnswer((_) async {});
+    when(() => authRepository.notifyLogout()).thenAnswer((_) {});
+
+    dio.httpClientAdapter = _TestAdapter((options, __, ___) async {
+      return ResponseBody.fromString(
+        '{}',
+        401,
+        headers: {
+          Headers.contentTypeHeader: ['application/json'],
+        },
+      );
+    });
+
+    expect(
+      () => dio.get('/protected'),
+      throwsA(isA<DioException>()),
+    );
+
+    verify(() => authRepository.refreshTokens()).called(1);
+    verify(() => authRepository.clearTokens()).called(1);
+    verify(() => authRepository.notifyLogout()).called(1);
+    verifyNever(() => authRepository.saveTokens(any()));
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:talker_flutter/talker_flutter.dart';
@@ -8,6 +10,7 @@ import 'package:tmdb_flutter_app/features/movies/domain/models/movies_entity.dar
 import 'package:tmdb_flutter_app/features/movies/domain/usecases/trending/trending_movies_use_case.dart';
 import 'package:tmdb_flutter_app/tmdb_flutter_app.dart';
 import 'package:tmdb_flutter_app/features/auth/domain/entities/auth_session.dart';
+import 'package:tmdb_flutter_app/features/auth/domain/entities/auth_tokens.dart';
 import 'package:tmdb_flutter_app/features/auth/domain/exceptions/auth_exception.dart';
 import 'package:tmdb_flutter_app/features/auth/domain/repositories/auth_repository.dart';
 
@@ -115,12 +118,16 @@ void main() {
   });
 }
 class _FakeAuthRepository implements AuthRepository {
-  _FakeAuthRepository({String? apiKey, AuthSession? session})
+  _FakeAuthRepository({String? apiKey, AuthSession? session, AuthTokens? tokens})
       : _apiKey = apiKey,
-        _session = session;
+        _session = session,
+        _tokens = tokens;
 
   String? _apiKey;
   AuthSession? _session;
+  AuthTokens? _tokens;
+  final StreamController<void> _logoutController =
+      StreamController<void>.broadcast();
 
   @override
   Future<void> clearApiKey() async {
@@ -178,4 +185,31 @@ class _FakeAuthRepository implements AuthRepository {
 
   @override
   Future<bool> validateApiKey(String apiKey) async => true;
+
+  @override
+  Future<String?> getAccessToken() async => _tokens?.accessToken;
+
+  @override
+  Future<AuthTokens?> getTokens() async => _tokens;
+
+  @override
+  Future<void> saveTokens(AuthTokens tokens) async {
+    _tokens = tokens;
+  }
+
+  @override
+  Future<void> clearTokens() async {
+    _tokens = null;
+  }
+
+  @override
+  Future<AuthTokens?> refreshTokens() async => _tokens;
+
+  @override
+  Stream<void> get logoutStream => _logoutController.stream;
+
+  @override
+  void notifyLogout() {
+    _logoutController.add(null);
+  }
 }


### PR DESCRIPTION
## Summary
- persist OAuth tokens alongside existing auth data
- add an AuthInterceptor that attaches bearer headers, refreshes tokens on 401 responses, and signals logout failures
- wire the interceptor into Dio configuration and add unit tests for header injection and refresh flows

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1a660e120832399ac18104c75d2de